### PR TITLE
Update activeOntologyTerm after acting on dependent param change

### DIFF
--- a/Client/src/Actions/FilterParamActions.ts
+++ b/Client/src/Actions/FilterParamActions.ts
@@ -121,6 +121,7 @@ export interface InvalidateOntologyTermsAction {
   type: typeof INVALIDATE_ONTOLOGY_TERMS;
   payload: Ctx & {
     retainedFields: string[];
+    activeOntologyTerm: string;
   };
 }
 

--- a/Client/src/Components/AttributeFilter/SingleFieldFilter.jsx
+++ b/Client/src/Components/AttributeFilter/SingleFieldFilter.jsx
@@ -30,7 +30,7 @@ export default class SingleFieldFilter extends React.Component {
   render() {
     const { activeField, activeFieldState, filters } = this.props;
 
-    const FieldDetail = activeField == null ? null
+    const FieldDetail = (activeField == null || activeFieldState == null) ? null
       : activeFieldState.summary.valueCounts.length === 0 ? EmptyValues
       : isRange(activeField) == false ? MembershipField
       : activeField.type == 'string' ? MembershipField
@@ -46,7 +46,7 @@ export default class SingleFieldFilter extends React.Component {
 
     const restProps = omit(this.props, ['filters']);
 
-    return (
+    return FieldDetail && (
       <React.Fragment>
         <FieldDetail
           filter={filter}

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -201,7 +201,8 @@ const observeUpdateDependentParamsActiveField: Observer = (action$, state$, { wd
             searchName,
             parameter,
             paramValues,
-            retainedFields: [/* activeOntologyTerm */]
+            retainedFields: [/* activeOntologyTerm */],
+            activeOntologyTerm: activeField
           })),
           activeField ? getOntologyTermSummary(wdkService, parameter.name, questionState, activeField) : empty() as Observable<Action>,
           getSummaryCounts(wdkService, parameter.name, questionState)

--- a/Client/src/Views/Question/Params/FilterParamNew/State.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/State.ts
@@ -106,6 +106,7 @@ export function reduce(state: State = initialState, action: Action): State {
     case INVALIDATE_ONTOLOGY_TERMS:
       return {
         ...state,
+        activeOntologyTerm: action.payload.activeOntologyTerm,
         fieldStates: mapValues(state.fieldStates, (fieldState, key) =>
           action.payload.retainedFields.includes(key)
             ? fieldState


### PR DESCRIPTION
Also patch SingleFieldFilter to properly be null in the intermetiate state of no data

I have question rendering as a dropdown with user dataset IDs at the top,  with the filter params at the bottom depending on the user dataset.
It didn't work after changing the user dataset because there was stale state: activeOntologyTerm referred to the filter for a previous dataset.
Now after the user dataset changes, the filter params starts "afresh", and is usable.


After this change and a rebuild, the UI starts to work on wbazant.microbiomedb.org - I can give you  credentials for a prepared QA account that has good data for testing if you want to see the change in action. **Not tested anywhere else** and this is my first change to WDKClient so I don't have a great overview of the codebase. Needs review!