### PR TITLE
Only render the CheckboxTreeNode children if the node is visible and expanded

### DIFF
--- a/Client/src/Components/CheckboxTree/CheckboxTreeNode.tsx
+++ b/Client/src/Components/CheckboxTree/CheckboxTreeNode.tsx
@@ -137,7 +137,7 @@ class CheckboxTreeNode<T> extends Component<Props<T>> {
             </label>
           )}
         </div>
-        {isLeafNode ? null :
+        { !isLeafNode && isVisible && isExpanded &&
           <ul className={listClassName} style={childrenVisibilityCss}>
             {getNodeChildren(node).map((child, index) =>
               <CheckboxTreeNode


### PR DESCRIPTION
Otherwise React spends a long time processing them all upfront.

The functionality is still not ideal when there are very many of nodes representing e.g. distinct species in a taxonomic tree, but with this change it at least happens after opening the relevant checkbox, instead of later. 

This can happen for user datasets, because people can upload whatever they want, but also on the live site in searches for taxon abundance.

