### PR TITLE
QuestionStoreModule can handle params specified in a URL

### DIFF
--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -655,8 +655,7 @@ function initialParamDataFromStep(step: Step): Record<string, string> {
 
 function initialParamDataWithDatasetParamSpecialCase(initialParamData: Record<string, string>){
   return Object.keys(initialParamData).reduce(function(result, paramName) {
-    const k = paramName.indexOf(".idList") > -1 ? paramName.replace(".idList", "") : paramName;
-    return Object.assign(result, {[k] : initialParamData[paramName]});
+    return paramName.indexOf(".idList") > -1 ? result : Object.assign(result, {[paramName] : initialParamData[paramName]});
   }, {});
 }
 


### PR DESCRIPTION
Things changed:

1) extractRealParamValues wasn't working correctly for filter params.

It couldn't make a desired initial state of filters, `"{"filters":[]}"` when providing param.biom_dataset=17298 in the URL:
```
makeDefaultParamValues(question.parameters)
{biom_dataset: "17321", samples_filter_metadata_user: "{"filters":[]}"}
extractRealParamValues(question.parameters, initialParamData)
{biom_dataset: "17298", samples_filter_metadata_user: ""}
```

"" is not a valid state of filters, because it's not valid JSON. There
was an error in the call to JSON.parse in FilterParamUtils.getFilters.

2) getQuestionGivenParameters was only called when there's a step
params from URL (initialParamData) also need this call.
Otherwise, the question object retrieved is wrong when there are
dependent parameters (by corresponding to a default, and not initial,
value)

Concretely: samples_filter_metadata_user had a list of samples, and that
list of samples was for a dataset 17321 (default by being first on the
list) rather than dataset 17298 (initial by being specified in the URL)