### PR TITLE
Error handling fixes

### DIFF
--- a/Client/src/Components/Overlays/Dialog.css
+++ b/Client/src/Components/Overlays/Dialog.css
@@ -33,7 +33,7 @@ body.wdk-ModalOpen {
   position: fixed;
   top: 50vh;
   left: 50vw;
-  z-index: 100;
+  z-index: 1;
   height: 0px;
   width: 0px;
   display: flex;

--- a/Client/src/StoreModules/UnhandledErrorStoreModule.ts
+++ b/Client/src/StoreModules/UnhandledErrorStoreModule.ts
@@ -57,7 +57,7 @@ export function observe(action$: ActionsObservable<Action>, state$: StateObserva
       try {
         const { unhandledError: { error, id, info } } = action.payload;
         console.error(error);
-        wdkService.submitErrorIfNot500(error instanceof Error ? error : new Error(String(error)), { id, info });
+        await wdkService.submitErrorIfNot500(error instanceof Error ? error : new Error(String(error)), { id, info });
       }
       catch (error) {
         console.error('Error logging request failed:', error);

--- a/Client/src/StoreModules/UnhandledErrorStoreModule.ts
+++ b/Client/src/StoreModules/UnhandledErrorStoreModule.ts
@@ -53,9 +53,15 @@ export function observe(action$: ActionsObservable<Action>, state$: StateObserva
   // log errors as they come in
   const notify$: Observable<never> = action$.pipe(
     filter(notifyUnhandledError.isOfType),
-    tap(action => {
-      const { unhandledError: { error, id, info } } = action.payload;
-      wdkService.submitErrorIfNot500(error instanceof Error ? error : new Error(String(error)), { id, info });
+    tap(async action => {
+      try {
+        const { unhandledError: { error, id, info } } = action.payload;
+        console.error(error);
+        wdkService.submitErrorIfNot500(error instanceof Error ? error : new Error(String(error)), { id, info });
+      }
+      catch (error) {
+        console.error('Error logging request failed:', error);
+      }
     }),
     mergeMapTo(EMPTY),
 


### PR DESCRIPTION
This fixes two issues:
1. Dialogs covering the error modal.
2. Infinite loop when `submitError` throws.