### PR TITLE
Show message to user when attempting to access an unowned strategy

### DIFF
--- a/Client/src/Controllers/StrategyWorkspaceController.tsx
+++ b/Client/src/Controllers/StrategyWorkspaceController.tsx
@@ -121,7 +121,7 @@ function ChildView({ allowEmptyOpened, queryParams, dispatch, subPath, openedStr
   // Prevent opened tab from being selecting while data needed for redirect above is being loaded
   if (openedStrategies == null || strategySummaries == null) return <Loading/>;
 
-  if (!ownsActiveStrategy) return <UnownedStrategy/>;
+  if (activeStrategyId != null && !ownsActiveStrategy) return <UnownedStrategy/>;
 
   switch(childView.type) {
     case 'openedStrategies':

--- a/Client/src/Controllers/StrategyWorkspaceController.tsx
+++ b/Client/src/Controllers/StrategyWorkspaceController.tsx
@@ -1,5 +1,5 @@
 import { toNumber, last } from 'lodash';
-import React, {useEffect, useLayoutEffect, useMemo} from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { connect } from 'react-redux';
 import {Dispatch} from 'redux';
 
@@ -17,6 +17,7 @@ import { StrategyActionModal } from 'wdk-client/Views/Strategy/StrategyControls'
 import {transitionToInternalPage} from 'wdk-client/Actions/RouterActions';
 import StrategyHelpPage from 'wdk-client/Views/Strategy/StrategyHelpPage';
 import Loading from 'wdk-client/Components/Loading';
+import UnownedStrategy from 'wdk-client/Views/Strategy/UnownedStrategy';
 
 interface OwnProps {
   workspacePath: string;
@@ -117,15 +118,10 @@ function ChildView({ allowEmptyOpened, queryParams, dispatch, subPath, openedStr
     }
   }, [activeStrategyId, activeStepId, ownsActiveStrategy]);
 
-  // If the user is tryting to navigate to a strategy they don't own, redirect them
-  useLayoutEffect(() => {
-    if (activeStrategyId && !ownsActiveStrategy) {
-      dispatch(transitionToInternalPage('/workspace/strategies/all', { replace: true }));
-    }
-  }, [activeStrategyId, ownsActiveStrategy]);
-
   // Prevent opened tab from being selecting while data needed for redirect above is being loaded
   if (openedStrategies == null || strategySummaries == null) return <Loading/>;
+
+  if (!ownsActiveStrategy) return <UnownedStrategy/>;
 
   switch(childView.type) {
     case 'openedStrategies':

--- a/Client/src/Views/Strategy/UnownedStrategy.tsx
+++ b/Client/src/Views/Strategy/UnownedStrategy.tsx
@@ -9,7 +9,7 @@ export default function UnownedStrategy() {
     <Banner banner={{
       type: 'danger',
       message: <div style={{ fontSize: '1.25em' }}>
-        The requested strategy does not exist, or you do not own it. If the requested strategy belongs to someone else, ask them to use the share button (<IconAlt fa={StrategyActions.share.iconName}/>) to share the strategy with you. <Link to="/workspace/strategies">Dismiss</Link>
+        The requested strategy does not exist, or it belongs to another user. In the latter case, ask them to use the share button (<IconAlt fa={StrategyActions.share.iconName}/>) to generate a valid URL that you may use to make a copy of their strategy. <Link to="/workspace/strategies">Dismiss</Link>
       </div>
     }}/>
   );

--- a/Client/src/Views/Strategy/UnownedStrategy.tsx
+++ b/Client/src/Views/Strategy/UnownedStrategy.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Link } from "react-router-dom";
+import Banner from 'wdk-client/Components/Banners/Banner';
+import { IconAlt } from 'wdk-client/Components';
+import { StrategyActions } from './StrategyControls';
+
+export default function UnownedStrategy() {
+  return (
+    <Banner banner={{
+      type: 'danger',
+      message: <div style={{ fontSize: '1.25em' }}>
+        The requested strategy does not exist, or you do not own it. If the requested strategy belongs to someone else, ask them to use the share button (<IconAlt fa={StrategyActions.share.iconName}/>) to share the strategy with you. <Link to="/workspace/strategies">Dismiss</Link>
+      </div>
+    }}/>
+  );
+}


### PR DESCRIPTION
This pull request introduces a message to the user when they try to access a strategy that they do not own. It is not know if the strategy actually exists, so the message has to support multiple possibilities.

This behavior can be seen at https://dfalke-b.plasmodb.org/plasmo.dfalke/app/workspace/strategies/123456789