### PR TITLE
FilterParamNew: add paging to large membership fields

### DIFF
--- a/Client/src/Components/Mesa/Ui/MesaController.jsx
+++ b/Client/src/Components/Mesa/Ui/MesaController.jsx
@@ -18,14 +18,10 @@ class MesaController extends React.Component {
 
   renderPaginationMenu () {
     const { uiState, eventHandlers } = this.props;
-    const { pagination } = uiState ? uiState : {};
-    const { currentPage, totalPages, totalRows, rowsPerPage } = pagination ? pagination : {};
-    const { onPageChange, onRowsPerPageChange } = eventHandlers ? eventHandlers : {};
 
-    if (!onPageChange) return null;
+    if (!uiState || !eventHandlers || !uiState.pagination || !eventHandlers.onPageChange) return null;
 
-    const props = { currentPage, totalPages, totalRows, rowsPerPage, onPageChange, onRowsPerPageChange };
-    return <PaginationMenu {...props} />
+    return <PaginationMenu {...uiState.pagination} {...eventHandlers} />
   }
 
   renderToolbar () {

--- a/Client/src/Components/Mesa/Ui/PaginationMenu.jsx
+++ b/Client/src/Components/Mesa/Ui/PaginationMenu.jsx
@@ -133,7 +133,7 @@ class PaginationMenu extends React.PureComponent {
   }
 
   render () {
-    const { currentPage, rowsPerPage, totalRows, disallowClick } = this.props;
+    const { currentPage, rowsPerPage, totalRows } = this.props;
     const totalPages = this.getTotalPages();
 
     const PageList = this.renderPageList;
@@ -145,7 +145,7 @@ class PaginationMenu extends React.PureComponent {
     const showPageList = totalRows > rowsPerPage;
 
     return (
-      <div className={disallowClick ? "PaginationMenu PaginationMenu-DisallowClick" : "PaginationMenu"}>
+      <div className="PaginationMenu">
         <span className="Pagination-Spacer" />
         {showPageList && <RelativeLink relative="previous" />}
         {showPageList && <PageList />}
@@ -163,8 +163,7 @@ PaginationMenu.propTypes = {
   rowsPerPage: PropTypes.number,
   onPageChange: PropTypes.func,
   rowsPerPageOptions: PropTypes.array,
-  onRowsPerPageChange: PropTypes.func,
-  disallowClick: PropTypes.bool
+  onRowsPerPageChange: PropTypes.func
 };
 
 export default PaginationMenu;

--- a/Client/src/Components/Mesa/Ui/PaginationMenu.jsx
+++ b/Client/src/Components/Mesa/Ui/PaginationMenu.jsx
@@ -133,7 +133,7 @@ class PaginationMenu extends React.PureComponent {
   }
 
   render () {
-    const { currentPage, rowsPerPage, totalRows } = this.props;
+    const { currentPage, rowsPerPage, totalRows, disallowClick } = this.props;
     const totalPages = this.getTotalPages();
 
     const PageList = this.renderPageList;
@@ -145,7 +145,7 @@ class PaginationMenu extends React.PureComponent {
     const showPageList = totalRows > rowsPerPage;
 
     return (
-      <div className="PaginationMenu">
+      <div className={disallowClick ? "PaginationMenu PaginationMenu-DisallowClick" : "PaginationMenu"}>
         <span className="Pagination-Spacer" />
         {showPageList && <RelativeLink relative="previous" />}
         {showPageList && <PageList />}
@@ -163,7 +163,8 @@ PaginationMenu.propTypes = {
   rowsPerPage: PropTypes.number,
   onPageChange: PropTypes.func,
   rowsPerPageOptions: PropTypes.array,
-  onRowsPerPageChange: PropTypes.func
+  onRowsPerPageChange: PropTypes.func,
+  disallowClick: PropTypes.bool
 };
 
 export default PaginationMenu;

--- a/Client/src/Components/Mesa/style/Ui/Pagination.scss
+++ b/Client/src/Components/Mesa/style/Ui/Pagination.scss
@@ -1,4 +1,10 @@
 .MesaComponent {
+
+  .PaginationMenu-DisallowClick {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
   .PaginationMenu {
     padding: 10px 0;
     text-align: center;

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParamNew.tsx
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParamNew.tsx
@@ -35,6 +35,7 @@ export default class FilterParamNew extends React.PureComponent<Props> {
     this._handleActiveFieldChange = this._handleActiveFieldChange.bind(this);
     this._handleFilterChange = this._handleFilterChange.bind(this);
     this._handleMemberSort = this._handleMemberSort.bind(this);
+    this._handleMemberPaginationChange = this._handleMemberPaginationChange.bind(this);
     this._handleMemberSearch = this._handleMemberSearch.bind(this);
     this._handleRangeScaleChange = this._handleRangeScaleChange.bind(this);
   }
@@ -105,6 +106,25 @@ export default class FilterParamNew extends React.PureComponent<Props> {
     }));
   }
 
+  _handleMemberPaginationChange(field: Field, pagination: MemberFieldState['pagination']) {
+    if (isRange(field)) {
+      throw new Error(`Cannot paginate a range field.`);
+    }
+
+    const filters = this._getFiltersFromValue(this.props.value);
+    const filter = filters.find(filter => filter.field === field.term) as MemberFilter;
+    const fieldState = this.props.uiState.fieldStates[field.term] as MemberFieldState;
+
+    this.props.dispatch(updateFieldState({
+      ...this.props.ctx,
+      field: field.term,
+      fieldState: {
+        ...fieldState,
+        pagination
+      }
+    }));
+  }
+
   _handleMemberSearch(field: Field, searchTerm: string) {
     const fieldState = this.props.uiState.fieldStates[field.term] as MemberFieldState
     this.props.dispatch(updateFieldState({
@@ -155,6 +175,7 @@ export default class FilterParamNew extends React.PureComponent<Props> {
           onActiveFieldChange={this._handleActiveFieldChange}
           onFieldCountUpdateRequest={this._handleFieldCountUpdateRequest}
           onMemberSort={this._handleMemberSort}
+          onMemberPaginationChange={this._handleMemberPaginationChange}
           onMemberSearch={this._handleMemberSearch}
           onRangeScaleChange={this._handleRangeScaleChange}
         />

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -27,6 +27,16 @@ const defaultMemberFieldSort: MemberFieldState['sort'] = {
   direction: 'asc',
   groupBySelected: false
 }
+function firstPageForRows(numRows: number) : MemberFieldState['pagination'] {
+  const pageSize = 100;
+  return ({
+    totalRows: numRows,
+    currentPage: 1,
+    rowsPerPage: Math.min(numRows, pageSize),
+    totalPages: Math.ceil(numRows / pageSize),
+    rowsPerPageOptions: [0.5,1,2,5,10].map(n => n * pageSize)
+  });
+}
 
 // Observers
 // ---------
@@ -261,6 +271,7 @@ function getOntologyTermSummary(
             invalid: false,
             loading: false,
             sort: defaultMemberFieldSort,
+            pagination: firstPageForRows(summary.valueCounts.length),
             searchTerm: '',
             summary: {
               ...summary,

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -27,16 +27,6 @@ const defaultMemberFieldSort: MemberFieldState['sort'] = {
   direction: 'asc',
   groupBySelected: false
 }
-function firstPageForRows(numRows: number) : MemberFieldState['pagination'] {
-  const pageSize = 100;
-  return ({
-    totalRows: numRows,
-    currentPage: 1,
-    rowsPerPage: Math.min(numRows, pageSize),
-    totalPages: Math.ceil(numRows / pageSize),
-    rowsPerPageOptions: [0.5,1,2,5,10].map(n => n * pageSize)
-  });
-}
 
 // Observers
 // ---------
@@ -271,7 +261,8 @@ function getOntologyTermSummary(
             invalid: false,
             loading: false,
             sort: defaultMemberFieldSort,
-            pagination: firstPageForRows(summary.valueCounts.length),
+            currentPage: 1,
+            rowsPerPage: 100,
             searchTerm: '',
             summary: {
               ...summary,

--- a/Client/src/Views/Question/Params/FilterParamNew/State.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/State.ts
@@ -19,6 +19,14 @@ export type SortSpec = {
   direction: 'asc' | 'desc';
 };
 
+export type PaginationSpec = {
+  totalRows: number;
+  totalPages: number;
+  currentPage: number;
+  rowsPerPage: number;
+  rowsPerPageOptions: number[];
+};
+
 type BaseFieldState = {
   summary?: OntologyTermSummary;
   loading?: boolean;
@@ -29,6 +37,7 @@ type BaseFieldState = {
 export type MemberFieldState = BaseFieldState & {
   sort: SortSpec;
   searchTerm: string;
+  pagination: PaginationSpec;
 }
 
 export type RangeFieldState = BaseFieldState & {

--- a/Client/src/Views/Question/Params/FilterParamNew/State.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/State.ts
@@ -19,14 +19,6 @@ export type SortSpec = {
   direction: 'asc' | 'desc';
 };
 
-export type PaginationSpec = {
-  totalRows: number;
-  totalPages: number;
-  currentPage: number;
-  rowsPerPage: number;
-  rowsPerPageOptions: number[];
-};
-
 type BaseFieldState = {
   summary?: OntologyTermSummary;
   loading?: boolean;
@@ -37,7 +29,8 @@ type BaseFieldState = {
 export type MemberFieldState = BaseFieldState & {
   sort: SortSpec;
   searchTerm: string;
-  pagination: PaginationSpec;
+  currentPage: number;
+  rowsPerPage: number;
 }
 
 export type RangeFieldState = BaseFieldState & {


### PR DESCRIPTION
Can be tested on https://wbazant.microbiomedb.org/mbio.wbazant/app/search/sample/SamplesByMetadata_otuDADA2_MALED_healthy_RSRC with an apidb password - some sample details like "SRA Experiment ID" are alternative IDs, and there's over a thousand rows. I acknowledge there's little very point for MicrobiomeDB to show this study while offer those filters, but it's there, and can be used as a test case.

Main rationale of this feature is to make improperly large membership fields usable. This came up for user datasets in MicrobiomeDB and an example input from Earth Microbiome Project, containing thousands of unannotated samples. The UI broke down on this case because rendering of all rows took too long.

Only page if there are over 100 values: there shouldn't usually be this many.

Offer page sizes of 50, 100, 200, and 1000. Changing pages tries to preserve values that are being shown.

When a search term is entered:
- set lower opacity for a grey out effect
- set pointer events to none
- use page size as maximum search count

Add an "indeterminate" state of a Select All checkbox, when some elements are selected. Clicking "Select All" on paged rows selects the current page (similar to behaviour with a search term).
One consequence is that it's not possible to unclick a page. I tried to make it work but it was difficult to get something non-broken, so went for consistency in the end.

Fix a small bug in MesaController.jsx, renderPaginationMenu: the parameter `rowsPerPageOptions` wasn't passed along.

MembershipField.jsx small refactor: make `getRows()` a method similarly named to `getFilteredRows()`.