### PR TITLE
Redirect to root step if step id is invalid

### DIFF
--- a/Client/src/Controllers/StrategyViewController.tsx
+++ b/Client/src/Controllers/StrategyViewController.tsx
@@ -62,7 +62,7 @@ function StrategyViewController(props: Props) {
 
   // Select root step if no step is selected
   useEffect(() => {
-    if (selectedStrategy && selectedStrategy.strategy && stepId == null) {
+    if (selectedStrategy && selectedStrategy.strategy && (stepId == null || !(stepId in selectedStrategy.strategy.steps))) {
       dispatch(
         transitionToInternalPage(
           `/workspace/strategies/${selectedStrategy.strategy.strategyId}/${selectedStrategy.strategy.rootStepId}`,


### PR DESCRIPTION
Redirect to root step if id is not valid for existing strategy.