### PR TITLE
Fix syntax error causing table state to get lost.

### DIFF
--- a/Client/src/Components/AttributeFilter/MembershipField.jsx
+++ b/Client/src/Components/AttributeFilter/MembershipField.jsx
@@ -502,7 +502,7 @@ class MembershipTable extends React.PureComponent {
     var useSort = this.isSortEnabled();
     var useSearch = this.isSearchEnabled();
     var usePagination = this.isPaginationEnabled();
-    const {currentPage, rowsPerPage, searchTerm, uiStateOther} = this.props.activeFieldState;
+    const {currentPage, rowsPerPage, searchTerm, ...uiStateOther} = this.props.activeFieldState;
 
     const rows = this.getRows();
     let filteredRows = this.getRows();


### PR DESCRIPTION
Fix syntax error that was causing ui state to get lost. Bug report: https://redmine.apidb.org/issues/41341