### PR TITLE
When clicking the "edit" button on a step box, only open one step details dialog

### DIFF
--- a/Client/src/Actions/StrategyPanelActions.ts
+++ b/Client/src/Actions/StrategyPanelActions.ts
@@ -26,11 +26,6 @@ export const fulfillStrategyPanelVisibility = makeActionCreator(
   (viewId: string, isVisible: boolean) => ({ isVisible, viewId })
 );
 
-export const setStepDetailsVisibility = makeActionCreator(
-  'strategyPanel/setStepDetailsVisibility',
-  (viewId: string, stepId: number | undefined) => ({ stepId, viewId })
-);
-
 export const setInsertStepWizardVisibility = makeActionCreator(
   'strategyPanel/setInsertStepWizardVisibility',
   (viewId: string, addType: AddType | undefined) => ({ addType, viewId })
@@ -73,7 +68,6 @@ export type Action =
   | InferAction<typeof closeStrategyPanel>
   | InferAction<typeof requestStrategyPanelVisibilityChange>
   | InferAction<typeof fulfillStrategyPanelVisibility>
-  | InferAction<typeof setStepDetailsVisibility>
   | InferAction<typeof setInsertStepWizardVisibility>
   | InferAction<typeof setReviseFormVisibility>
   | InferAction<typeof setDeleteStepDialogVisibilty>

--- a/Client/src/Controllers/StrategyPanelController.tsx
+++ b/Client/src/Controllers/StrategyPanelController.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { requestDeleteStrategy, requestDuplicateStrategy, requestPatchStrategyProperties, requestRemoveStepFromStepTree, requestStrategy, requestUpdateStepProperties } from 'wdk-client/Actions/StrategyActions';
-import { nestStrategy, setInsertStepWizardVisibility, unnestStrategy, setReviseFormVisibility, openStrategyPanel, closeStrategyPanel, setStepDetailsVisibility } from 'wdk-client/Actions/StrategyPanelActions';
+import { nestStrategy, setInsertStepWizardVisibility, unnestStrategy, setReviseFormVisibility, openStrategyPanel, closeStrategyPanel } from 'wdk-client/Actions/StrategyPanelActions';
 import { createNewTab } from 'wdk-client/Core/MoveAfterRefactor/Actions/StepAnalysis/StepAnalysisActionCreators';
 import { RootState } from 'wdk-client/Core/State/Types';
 import { RecordClass, Question } from 'wdk-client/Utils/WdkModel';
@@ -12,7 +12,6 @@ import StrategyPanel from 'wdk-client/Views/Strategy/StrategyPanel';
 import { PartialUiStepTree, AddType } from 'wdk-client/Views/Strategy/Types';
 import {removeFromOpenedStrategies} from 'wdk-client/Actions/StrategyWorkspaceActions';
 import {transitionToInternalPage} from 'wdk-client/Actions/RouterActions';
-import { getStepIds } from 'wdk-client/Utils/StrategyUtils';
 
 interface OwnProps {
   viewId: string;
@@ -35,7 +34,6 @@ interface MappedProps {
 interface MappedDispatch {
   openStrategyPanel: (viewId: string) => void;
   closeStrategyPanel: (viewId: string) => void;
-  setDetailModalStepId: (stepId?: number) => void;
   setReviseFormStepId: (stepId?: number) => void;
   requestStrategy: (id: number) => void;
   onStrategyClose: () => void;
@@ -63,7 +61,6 @@ function mapStateToProps(state: RootState, ownProps: OwnProps): MappedProps {
   const insertStepVisibility = panelState && panelState.visibleInsertStepWizard;
   const nestedStrategyBranchIds = panelState ? panelState.nestedStrategyBranchIds : [];
   const reviseFormStepId = panelState && panelState.visibleReviseForm;
-  const detailModalStepId = panelState && panelState.visibleStepDetails;
   // FIXME
   const { recordClasses, questions } = state.globalData;
   const uiStepTree = (
@@ -72,7 +69,7 @@ function mapStateToProps(state: RootState, ownProps: OwnProps): MappedProps {
     questions &&
     makeUiStepTree(strategy, keyBy(recordClasses, 'urlSegment'), keyBy(questions, 'urlSegment'), nestedStrategyBranchIds)
   );
-  return { uiStepTree, insertStepVisibility, reviseFormStepId, detailModalStepId };
+  return { uiStepTree, insertStepVisibility, reviseFormStepId };
 }
 
 function mapDispatchToProps(dispatch: Dispatch, props: OwnProps): MappedDispatch {
@@ -85,7 +82,6 @@ function mapDispatchToProps(dispatch: Dispatch, props: OwnProps): MappedDispatch
       removeFromOpenedStrategies([strategyId]),
       transitionToInternalPage('/workspace/strategies')
     ],
-    setDetailModalStepId: (stepId?: number) => setStepDetailsVisibility(viewId, stepId),
     setReviseFormStepId: (stepId?: number) => setReviseFormVisibility(viewId, stepId),
     onStrategyCopy: () => requestDuplicateStrategy(strategyId),
     onStrategyDelete: () => requestDeleteStrategy(strategyId),

--- a/Client/src/Controllers/StrategyPanelController.tsx
+++ b/Client/src/Controllers/StrategyPanelController.tsx
@@ -28,7 +28,6 @@ interface MappedProps {
   uiStepTree?: PartialUiStepTree;
   insertStepVisibility?: AddType;
   reviseFormStepId?: number;
-  detailModalStepId?: number;
 }
 
 interface MappedDispatch {

--- a/Client/src/StoreModules/StrategyPanelStoreModule.ts
+++ b/Client/src/StoreModules/StrategyPanelStoreModule.ts
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import { Action } from 'wdk-client/Actions';
-import { nestStrategy, openStrategyPanel, setDeleteStepDialogVisibilty, setInsertStepWizardVisibility, setStepDetailsVisibility, setStrategyPanelHeightOverride, unnestStrategy, setReviseFormVisibility, closeStrategyPanel } from 'wdk-client/Actions/StrategyPanelActions';
+import { nestStrategy, openStrategyPanel, setDeleteStepDialogVisibilty, setInsertStepWizardVisibility, setStrategyPanelHeightOverride, unnestStrategy, setReviseFormVisibility, closeStrategyPanel } from 'wdk-client/Actions/StrategyPanelActions';
 import { indexByActionProperty, IndexedState } from 'wdk-client/Utils/ReducerUtils';
 import { fulfillPutStrategy, fulfillStrategy } from 'wdk-client/Actions/StrategyActions';
 import { AddType } from 'wdk-client/Views/Strategy/Types';
@@ -19,7 +19,6 @@ export type State = IndexedState<ViewState>;
 type ViewState = {
     strategyPanelIsVisible: boolean,
     strategyPanelHeightOverride?: number,  // user's choice of height
-    visibleStepDetails?: number,  // stepId or none if not shown
     visibleInsertStepWizard?: AddType  // AddType or none if not shown
     visibleReviseForm?: number  // stepId or none if not shown
     visibleDeleteStepDialog?: number  // stepId or none if not shown
@@ -42,10 +41,6 @@ type ViewState = {
       case openStrategyPanel.type:
       case closeStrategyPanel.type:
         return initialViewState;
-
-      case setStepDetailsVisibility.type: {
-        return { ...state, visibleStepDetails: action.payload.stepId };
-      }
   
       case setInsertStepWizardVisibility.type: {
         return { ...state, visibleInsertStepWizard: action.payload.addType };

--- a/Client/src/Views/Strategy/StepBoxes.tsx
+++ b/Client/src/Views/Strategy/StepBoxes.tsx
@@ -76,7 +76,7 @@ function StepTree(props: StepBoxesProps) {
     <React.Fragment>
       {primaryInput && <StepTree {...props} stepTree={primaryInput} isDeleteable={primaryInputIsDeletable} />}
       <div className={cx('--Slot')}>
-        <Plugin<StepBoxProps>
+        <Plugin
           context={{
             type: 'stepBox',
             name: step.searchName,
@@ -90,8 +90,6 @@ function StepTree(props: StepBoxesProps) {
             isExpanded: false,
             areInputsValid,
             isDeleteable,
-            isDetailVisible: props.stepDetailVisibility === step.id,
-            setDetailVisibility: isVisible => props.setStepDetailVisibility(isVisible ? step.id : undefined),
             renameStep: (newName: string) => props.onRenameStep(step.id, newName),
             // no-op; primary inputs cannot be nested
             makeNestedStrategy: noop,
@@ -111,7 +109,7 @@ function StepTree(props: StepBoxesProps) {
         {secondaryInput && (
           !isCompleteUiStepTree(secondaryInput) ? <UnknownQuestionStepBox stepTree={secondaryInput} deleteStep={() => props.onDeleteStep(secondaryInput.step.id)}/>
             : (
-              <Plugin<StepBoxProps>
+              <Plugin
                 context={{
                   type: 'stepBox',
                   name: secondaryInput.step.searchName,
@@ -125,8 +123,6 @@ function StepTree(props: StepBoxesProps) {
                   areInputsValid: secondaryInput.areInputsValid,
                   isExpanded: step.expanded,
                   isDeleteable,
-                  isDetailVisible: props.stepDetailVisibility === secondaryInput.step.id,
-                  setDetailVisibility: isVisible => props.setStepDetailVisibility(isVisible ? secondaryInput.step.id : undefined),
                   renameStep: (newName: string) => {
                     if (secondaryInput.isNested) {
                       props.onRenameNestedStrategy(step.id, newName);
@@ -296,7 +292,7 @@ function PreviewStepTree(props: PreviewStepBoxesProps) {
   const { step, primaryInput, secondaryInput, areInputsValid } = stepTree;
 
   const existingStepBox = (
-    <Plugin<StepBoxProps>
+    <Plugin
       context={{
         type: 'stepBox',
         name: step.searchName,
@@ -307,8 +303,6 @@ function PreviewStepTree(props: PreviewStepBoxesProps) {
         stepTree,
         isNested: false,
         areInputsValid,
-        isDetailVisible: false,
-        setDetailVisibility: () => {},
         ...existingStepPreviewProps
       }}
       defaultComponent={ExistingStepPreviewBox}
@@ -319,7 +313,7 @@ function PreviewStepTree(props: PreviewStepBoxesProps) {
     secondaryInput && (
       !isCompleteUiStepTree(secondaryInput)
         ? <UnknownQuestionStepBox stepTree={secondaryInput} deleteStep={noop} />
-        : <Plugin<StepBoxProps>
+        : <Plugin
             context={{
               type: 'stepBox',
               name: secondaryInput.step.searchName,
@@ -330,8 +324,6 @@ function PreviewStepTree(props: PreviewStepBoxesProps) {
               stepTree: secondaryInput,
               isNested: secondaryInput.isNested,
               areInputsValid: secondaryInput.areInputsValid,
-              isDetailVisible: false,
-              setDetailVisibility: () => {},
               ...existingStepPreviewProps
             }}
             defaultComponent={ExistingStepPreviewBox}
@@ -473,7 +465,9 @@ const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
     (secondaryInput == null || isCompleteUiStepTree(secondaryInput))
   );
 
-  const editButton = hasValidSearch || isNested
+  const editButton = isPreview
+    ? null
+    : hasValidSearch || isNested
     ? (
       <button
         type="button"
@@ -492,9 +486,9 @@ const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
       </button>
     )
 
-  const stepDetails = (
-    <StepDetailsDialog {...props} allowRevise={allowRevise} isOpen={isDetailVisible} onClose={() => setDetailVisibility(false)}/>
-  );
+  const stepDetails = isPreview
+    ? null
+    : <StepDetailsDialog {...props} allowRevise={allowRevise} isOpen={isDetailVisible} onClose={() => setDetailVisibility(false)}/>;
 
   const filterIcon = step.isFiltered && (
     <i className={`${cx('--FilterIcon')} fa fa-filter`}/>
@@ -523,8 +517,8 @@ const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
       >
         <StepComponent {...props} />
       </NavLink>
-      {!isPreview && editButton}
-      {!isPreview && stepDetails}
+      {editButton}
+      {stepDetails}
       {filterIcon}
     </div>
   );

--- a/Client/src/Views/Strategy/StepBoxes.tsx
+++ b/Client/src/Views/Strategy/StepBoxes.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import Tooltip from 'wdk-client/Components/Overlays/Tooltip';
 import { Plugin } from 'wdk-client/Utils/ClientPlugin';
@@ -452,8 +452,10 @@ function SlotContent({
 }
 
 const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
-  const { isNested, areInputsValid, stepTree, deleteStep, isDetailVisible, setDetailVisibility } = props;
+  const { isNested, areInputsValid, stepTree, deleteStep } = props;
   const { step, color, primaryInput, secondaryInput } = stepTree;
+
+  const [ isDetailVisible, setDetailVisibility ] = useState(false);
 
   const StepComponent = isCombineUiStepTree(stepTree) && !isNested ? CombineStepBoxContent
     : isTransformUiStepTree(stepTree) && !isNested ? TransformStepBoxContent

--- a/Client/src/Views/Strategy/StrategyPanel.tsx
+++ b/Client/src/Views/Strategy/StrategyPanel.tsx
@@ -11,7 +11,6 @@ import './StrategyPanel.css';
 import {Plugin} from 'wdk-client/Utils/ClientPlugin';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
 import { CommonModal as StrategyModal } from 'wdk-client/Components';
-import StepDetailsDialog from './StepDetailsDialog';
 
 const cx = makeClassNameHelper('StrategyPanel');
 
@@ -25,7 +24,6 @@ interface Props {
   detailModalStepId?: number;
   showCloseButton?: boolean;
   setReviseFormStepId: (stepId?: number) => void;
-  setDetailModalStepId: (stepId?: number) => void;
   onStrategyRename: (name: string) => void;
   onStrategyClose: () => void;
   onStrategyCopy: (signature: string) => void;
@@ -51,11 +49,9 @@ export default function StrategyPanel(props: Props) {
     strategy,
     insertStepVisibility,
     reviseFormStepId,
-    detailModalStepId,
     showCloseButton,
     onStrategyClose,
     setReviseFormStepId,
-    setDetailModalStepId,
     onShowInsertStep,
     onHideInsertStep,
     onMakeNestedStrategy,
@@ -69,7 +65,6 @@ export default function StrategyPanel(props: Props) {
   } = props;
 
   const reviseStep = reviseFormStepId != null && strategy != null ? strategy.steps[reviseFormStepId] : undefined;
-  const detailStep = detailModalStepId != null && strategy != null ? strategy.steps[detailModalStepId] : undefined;
 
   return (
     <div className={cx()}>
@@ -105,8 +100,6 @@ export default function StrategyPanel(props: Props) {
             <div className={cx('--StepBoxesContainer')}>
               <StepBoxes
                 stepTree={uiStepTree}
-                stepDetailVisibility={detailModalStepId}
-                setStepDetailVisibility={setDetailModalStepId}
                 setReviseFormStepId={setReviseFormStepId}
                 onShowInsertStep={onShowInsertStep}
                 onHideInsertStep={onHideInsertStep}

--- a/Client/src/Views/Strategy/StrategyPanel.tsx
+++ b/Client/src/Views/Strategy/StrategyPanel.tsx
@@ -21,7 +21,6 @@ interface Props {
   uiStepTree?: PartialUiStepTree;
   insertStepVisibility?: AddType;
   reviseFormStepId?: number;
-  detailModalStepId?: number;
   showCloseButton?: boolean;
   setReviseFormStepId: (stepId?: number) => void;
   onStrategyRename: (name: string) => void;

--- a/Client/src/Views/Strategy/Types.ts
+++ b/Client/src/Views/Strategy/Types.ts
@@ -73,8 +73,6 @@ export interface StepBoxesProps {
   stepTree: PartialUiStepTree;
   nestedStrategyBranchToRename?: number;
   isDeleteable?: boolean;
-  stepDetailVisibility?: number;
-  setStepDetailVisibility: (stepId?: number) => void;
   setReviseFormStepId: (stepId?: number) => void;
   onShowInsertStep: (addType: AddType) => void;
   onHideInsertStep: () => void;
@@ -95,8 +93,6 @@ export interface StepBoxProps<T extends UiStepTree = UiStepTree> {
   isExpanded: boolean;
   isDeleteable: boolean;
   isAnalyzable: boolean;
-  isDetailVisible: boolean;
-  setDetailVisibility: (isVisible: boolean) => void;
   renameStep: (newName: string) => void;
   makeNestedStrategy: () => void;
   makeUnnestStrategy: () => void;


### PR DESCRIPTION
Currently, when we try to "edit" the root of an expanded nested strategy, two step details dialogs open:

1. The associated `NestedStepDetails`
2. The `StepDetails` or `CombineStepDetails` for the nested strategy's root step 

The underlying issue is that... 

1. We are maintaining, via Redux state from the `StrategyPanelStoreModule`, the step id of the `visibleStepDetails`
2. The relation between step ids and step dialogs is not necessarily 1-1. It is 1-2 in the case where the step id is the root of an expanded nested strategy

This PR resolves this issue by moving the step details visibility from Redux state to local component state of each step box. Since there is a 1-1 correspondence between step boxes and step dialogs, this avoids the bug.

Note: I also considered keeping `visibleStepDetails` in the `StrategyPanelStoreModule` and updating its shape to something 1-1 like `{ stepId: number, isDialogForNestedStepDetails: boolean
 }` or `{ stepBoxId: number }`, but that felt like a more brittle solution.