### PR TITLE
Fix bug about order of actions: should first post the file, then transition

### DIFF
--- a/Client/src/Service/Mixins/UserUploadService.ts
+++ b/Client/src/Service/Mixins/UserUploadService.ts
@@ -142,13 +142,13 @@ export default (base: ServiceBase) => {
         method: 'POST',
         body: metaBody
       }
-    ).then(({jobId}) => {
+    ).then(({jobId}) =>
       fetchWithCredentials(
           '/user-datasets/'+jobId,
           'POST',
            fileBody
-      );
-    });
+      ).then(response => {})
+    );
   }
   function listStatusDetails():  Promise<Array<UserDatasetUpload>> {
     return fetchDecodedJsonOrThrowMessage(


### PR DESCRIPTION
I want the page to wait until the file body is posted, but then transition. But actually, that's not what it does - it transitions sometime between the first request (start upload, sets status as "awaiting upload") and the second. So, it leads to a screen which says "awaiting upload" while still posting the file (which I see for a larger file, when I open a network tab) which is not exactly a bug, but not how I wanted it either - I wanted the "new upload" screen to be at low opacity until the file is posted, and transition afterwards.

The bug scenario is that when the user refreshes the page (and it's very tempting, there's a button to refresh the page, etc.) the upload gets stuck as "awaiting upload" forever: the file does not complete loading, and the server never fails it.

This is wrong because of not returning the result of fetchWithCredentials.