### PR TITLE
Do a deep equality check to prevent unnecessary updates.

### DIFF
--- a/Client/src/Components/AttributeFilter/Histogram.jsx
+++ b/Client/src/Components/AttributeFilter/Histogram.jsx
@@ -91,7 +91,7 @@ var Histogram = (function() {
     componentDidUpdate(prevProps) {
       if (
         !isEqual(this.props.distribution, prevProps.distribution) ||
-        this.props.uiState !== prevProps.uiState
+        !isEqual(this.props.uiState, prevProps.uiState)
       ) {
         this.createPlot();
         this.drawPlotSelection();


### PR DESCRIPTION
This PR fixes an issue where the flot jquery plugin was being invoked numerous times in rapid succession. Due to how the plugin is invoked, it's possible for references to be removed before additional setup is complete. The commit in the PR performs a deep comparison of `uiState` to prevent unnecessary updates.