### PR TITLE
Gene page scroll fix

### DIFF
--- a/Client/src/Components/DataTable/DataTable.tsx
+++ b/Client/src/Components/DataTable/DataTable.tsx
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import RealTimeSearchBox from 'wdk-client/Components/SearchBox/RealTimeSearchBox';
-import { eq, once, uniqueId, uniqBy } from 'lodash';
+import { isEqual, once, uniqueId, uniqBy } from 'lodash';
 import React, { Component, PureComponent, ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { formatAttributeValue, lazy, wrappable } from 'wdk-client/Utils/ComponentUtils';
@@ -143,8 +143,7 @@ class DataTable extends PureComponent<Props, State> {
 
     let columnsChanged = didPropChange(this, prevProps, 'columns')
     let dataChanged = didPropChange(this, prevProps, 'data');
-    let sortingChanged = didPropChange(this, prevProps, 'sorting') &&
-      !eq(this.props.sorting, prevProps.sorting);
+    let sortingChanged = didPropChange(this, prevProps, 'sorting');
     let widthChanged = didPropChange(this, prevProps, 'width');
     let heightChanged = didPropChange(this, prevProps, 'height');
     let expandedRowsChanged = didPropChange(this, prevProps, 'expandedRows');
@@ -515,6 +514,6 @@ function formatSorting(columns: DataTables.ColumnSettings[], sorting: SortingDef
 }
 
 /** Return boolean indicating if a prop's value has changed. */
-function didPropChange(component: Component<Props, any>, prevProps: Props, propName: string) {
-  return (component.props as any)[propName] !== (prevProps as any)[propName];
+function didPropChange(component: Component<Props, any>, prevProps: Props, propName: keyof Props) {
+  return !isEqual(component.props[propName], prevProps[propName]);
 }

--- a/Client/src/Utils/DomUtils.ts
+++ b/Client/src/Utils/DomUtils.ts
@@ -40,17 +40,19 @@ export const addScrollAnchor = addScrollAnchor__loop
  * which mitigates the potential for race conditions.
  */
 function addScrollAnchor__loop(
-  container: Element,
+  container: HTMLElement,
   anchorNode = findAnchorNode(container)
 ) {
   let { scrollY } = window;
   let containerRect = container.getBoundingClientRect();
+  const offsetParent = container.offsetParent || document.body;
+  let parentSize = offsetParent.clientHeight;
   let animId: number;
 
   function loop() {
     animId = requestAnimationFrame(function() {
       loop();
-      if (containerHasResized()) {
+      if (parentSizeChanged() || containerHasResized()) {
         scrollToAnchor();
       }
       else if (pageHasScrolled()) {
@@ -58,6 +60,7 @@ function addScrollAnchor__loop(
       }
       scrollY = window.scrollY;
       containerRect = container.getBoundingClientRect();
+      parentSize = offsetParent.clientHeight;
     });
   }
 
@@ -68,6 +71,10 @@ function addScrollAnchor__loop(
   function updateAnchor() {
     anchorNode = findAnchorNode(container);
     console.debug('updating anchorNode', anchorNode);
+  }
+
+  function parentSizeChanged(): boolean {
+    return parentSize !== offsetParent.clientHeight;
   }
 
   function containerHasResized(): boolean {

--- a/Client/src/Views/Records/RecordUI.jsx
+++ b/Client/src/Views/Records/RecordUI.jsx
@@ -24,6 +24,7 @@ class RecordUI extends Component {
     this.monitorActiveSection = debounce(this.monitorActiveSection.bind(this), 100);
 
     this.recordMainSectionNode = null;
+    this.activeSectionTop = null;
   }
 
   componentDidMount() {
@@ -68,13 +69,15 @@ class RecordUI extends Component {
     console.debug(Date.now(), 'updated activeSection', activeSection);
     let newUrl = location.pathname + location.search + (activeSection ? '#' + activeSection : '');
     history.replaceState(null, null, newUrl);
+    this.activeSectionTop = activeElement && activeElement.getBoundingClientRect().top;
   }
 
   _scrollToActiveSection() {
     this.unmonitorActiveSection();
     let domNode = document.getElementById(location.hash.slice(1));
     if (domNode != null) {
-      domNode.scrollIntoView(true);
+      const rect = domNode.getBoundingClientRect();
+      if (rect.top !== this.activeSectionTop) domNode.scrollIntoView(true);
       console.debug(Date.now(), 'scrolled to active section', domNode, domNode.getBoundingClientRect().top);
     }
     this.monitorActiveSection();


### PR DESCRIPTION
This PR includes fixes that prevent the gene page from jumping around as content is added to the page (sections expanded, images loaded, etc).

This could use some additional testing before being merged. My dev site is currently built with this branch (note that it's configured as a FungiDB website): https://dfalke-b.fungidb.org.

Relevant redmine: https://redmine.apidb.org/issues/41132