### PR TITLE
Custom step name fixes

### DIFF
--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -74,6 +74,7 @@ export interface QuestionLoadedAction {
     paramValues: ParameterValues;
     initialParamData?: Record<string, string>;
     wdkWeight?: number;
+    customName?: string;
     stepValidation?: Step['validation'];
   }>
 }

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -162,7 +162,8 @@ function reduceQuestionState(state = {} as QuestionState, action: Action): Quest
           Object.assign(paramUIState, { [parameter.name]: paramReducer(parameter, undefined, { type: '@@parm-stub@@' }) }), {}),
         groupUIState: action.payload.question.groups.reduce((groupUIState, group) =>
           Object.assign(groupUIState, { [group.name]: { isVisible: group.isVisible }}), {}),
-        weight: toString(action.payload.wdkWeight)
+        weight: toString(action.payload.wdkWeight),
+        customName: toString(action.payload.customName)
       }
 
     case QUESTION_ERROR:
@@ -636,6 +637,7 @@ async function loadQuestion(
       paramValues,
       initialParamData, // Intentionally not initialParams to preserve previous behaviour ( an "INIT_PARAM" action triggered)
       wdkWeight,
+      customName: step?.customName,
       stepValidation: step && step.validation
     })
   }

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -1,6 +1,6 @@
 import { keyBy, mapValues, toString } from 'lodash';
 import { combineEpics, ofType, StateObservable, ActionsObservable } from 'redux-observable';
-import { EMPTY, Observable, Subject, from, merge } from 'rxjs';
+import { EMPTY, Observable, Subject, from, merge, of } from 'rxjs';
 import { debounceTime, filter, map, mergeAll, mergeMap, takeUntil } from 'rxjs/operators';
 
 import {
@@ -53,6 +53,7 @@ import { RootState } from 'wdk-client/Core/State/Types';
 import {
   requestCreateStrategy,
   requestPutStrategyStepTree,
+  requestUpdateStepProperties,
   requestUpdateStepSearchConfig,
   fulfillCreateStep,
   fulfillCreateStrategy
@@ -430,13 +431,22 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
       }
 
       if (submissionMetadata.type === 'edit-step') {
-        return requestUpdateStepSearchConfig(
-          submissionMetadata.strategyId,
-          submissionMetadata.stepId,
-          {
-            ...submissionMetadata.previousSearchConfig,
-            ...searchConfig
-          }
+        return of(
+          requestUpdateStepProperties(
+            submissionMetadata.strategyId,
+            submissionMetadata.stepId,
+            {
+              customName
+            }
+          ),
+          requestUpdateStepSearchConfig(
+            submissionMetadata.strategyId,
+            submissionMetadata.stepId,
+            {
+              ...submissionMetadata.previousSearchConfig,
+              ...searchConfig
+            }
+          )
         );
       }
 

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -638,7 +638,7 @@ async function loadQuestion(
       initialParamData, // Intentionally not initialParams to preserve previous behaviour ( an "INIT_PARAM" action triggered)
       wdkWeight,
       customName: step?.customName,
-      stepValidation: step && step.validation
+      stepValidation: step?.validation
     })
   }
   catch (error) {


### PR DESCRIPTION
This PR addresses two reported bugs for the "custom step name" functionality:

1. When adding a step, the "custom name" field on the search page is pre-populated with value from the most recent use of the form. (This is resolved by updating the `customName` whenever the active question changes.)

2. When revising a step, submitting a new "custom name" from the search page does not update the step's custom name. (This is resolved by issuing a step PATCH request. Before, we were just issuing a step PUT request to update the search config.)