### PR TITLE
User Dataset List: UX enhancements and bugfixes when changing metadata

### DIFF
--- a/Client/src/StoreModules/UserDatasetListStoreModule.ts
+++ b/Client/src/StoreModules/UserDatasetListStoreModule.ts
@@ -74,7 +74,10 @@ export function reduce(state: State = initialState, action: Action): State {
           ...state,
           userDatasetsById: {
             ...state.userDatasetsById,
-            [action.payload.userDataset.id]: action.payload.userDataset
+            [action.payload.userDataset.id]: {
+              isLoading: false,
+              resource: action.payload.userDataset
+            }
           }
         }
         : state;

--- a/Client/src/Views/UserDatasets/List/UserDatasetList.tsx
+++ b/Client/src/Views/UserDatasets/List/UserDatasetList.tsx
@@ -474,7 +474,6 @@ class UserDatasetList extends React.Component <Props, State> {
 
     const rows = userDatasets;
     const selectedDatasets = rows.filter(isRowSelected);
-
     const rootUrl = this.getRootUrl();
     const columns = this.getColumns();
     const actions = this.getTableActions();
@@ -504,6 +503,12 @@ class UserDatasetList extends React.Component <Props, State> {
 
     const totalPercent = totalSize / quotaSize;
 
+    const offerProjectToggle = userDatasets.some(
+      ({ projects }) => projects.some(
+        project => project !== projectName
+      )
+    );
+
     return (
       <div className="UserDatasetList">
         <Mesa state={MesaState.create(tableState)}>
@@ -530,13 +535,16 @@ class UserDatasetList extends React.Component <Props, State> {
                 <div style={{ flex: '0 0 auto', padding: '0 10px' }}>
                   Showing {filteredRows.length} of {rows.length} {`data set${rows.length == 1 ? '' : 's'}`}
                 </div>
-                <div className="UserDatasetList-ProjectToggle" style={{ flex: '0 0 auto', padding: '0 10px' }}>
-                  <Checkbox value={filterByProject} onChange={toggleProjectScope} />
-                  {' '}
-                  <div onClick={() => toggleProjectScope(!filterByProject)} style={{ display: 'inline-block' }}>
-                    Only show data sets related to <b>{projectName}</b>
+                {
+                  offerProjectToggle &&
+                  <div className="UserDatasetList-ProjectToggle" style={{ flex: '0 0 auto', padding: '0 10px' }}>
+                    <Checkbox value={filterByProject} onChange={toggleProjectScope} />
+                    {' '}
+                    <div onClick={() => toggleProjectScope(!filterByProject)} style={{ display: 'inline-block' }}>
+                      Only show data sets related to <b>{projectName}</b>
+                    </div>
                   </div>
-                </div>
+                }
                 <div style={{ flex: '0 0 auto', padding: '0 10px' }}>
                   <Icon fa="info-circle"/> {bytesToHuman(totalSize)} ({normalizePercentage(totalPercent)}%) of {bytesToHuman(quotaSize)} used
                 </div>

--- a/Client/src/Views/UserDatasets/UserDatasetStatus.tsx
+++ b/Client/src/Views/UserDatasets/UserDatasetStatus.tsx
@@ -39,8 +39,7 @@ export default function UserDatasetStatus(props: Props) {
     )
     : (
       <span>
-        This dataset is not compatible with resources in this release of {displayName}.
-        See <Link to={link + '#dataset-compatibility'}>Compatibility Information</Link> for more information.
+        This data set was uploaded but could not be installed, as it is not compatible with resources in this release of {displayName}.
       </span>
     )
   );


### PR DESCRIPTION
Opening this as a draft PR so @aurreco-uga can weigh in on the verbiage before it's merged.

This PR introduces two recently suggested UX improvements for the `UserDatasetList`:

1. Don't display the project toggle checkbox unless the user has at least one dataset from another project.

2. Update some of the `UserDatasetStatus` verbiage. (The existing verbiage for the "uploaded but not compatible with this release" case was misleading because `BiomDatasetDetail`s do not have the "compatibility section.")

In addition, a fix is provided for some bugs pertaining to editing details in the `UserDatasetList`. (See https://redmine.apidb.org/issues/40127 and https://redmine.apidb.org/issues/32168.)

**Note:** While this PR fixes the errors that were being thrown on the client, there appears to be additional service work to be done. The associated PUT requests to `/users/current/user-datasets/{datasetId}/meta` do not appear to be working correctly: when the client issues such a request, the service responds with a 204 status, but the response of subsequent `GET`s to `/users/current/user-datasets/{datasetId}` has the old metadata. This behavior occurs on live sites, qa sites, and my dev sites.