### PR TITLE
Introduce "useWdkServiceWithRefresh"

### DIFF
--- a/Client/src/Hooks/WdkServiceHook.ts
+++ b/Client/src/Hooks/WdkServiceHook.ts
@@ -9,27 +9,42 @@ export interface ServiceCallback<S extends WdkService, T> {
 
 type WdkServiceCallback<T> = ServiceCallback<WdkService, T>;
 
+function wdkServiceHookFactory(clearValueBeforeServiceCallback: boolean) {
+  return function<T>(callback: WdkServiceCallback<T>, deps?: any[]): T | undefined {
+    const [ value, setValue ] = useState<T>();
+    const dispatch = useDispatch();
+    useWdkEffect(wdkService => {
+      let doSetValue = true;
+      if (clearValueBeforeServiceCallback) {
+        setValue(undefined);
+      }
+      callback(wdkService).then(
+        value => {
+          if (doSetValue) setValue(value);
+        },
+        error => {
+          if (doSetValue) {
+            wdkService.submitErrorIfNot500(error);
+            dispatch(notifyUnhandledError(error));
+          }
+        });
+      return () => { doSetValue = false; }
+    }, deps)
+    return value;
+  }
+}
+
 /**
  * Use WdkService to extract data from the WDK Service REST API.
  * @param callback Returns a Promise whose resolved value is used
  *                 as the return value of this hook.
  */
-export function useWdkService<T>(callback: WdkServiceCallback<T>, deps?: any[]): T | undefined {
-  const [ value, setValue ] = useState<T>();
-  const dispatch = useDispatch();
-  useWdkEffect(wdkService => {
-    let doSetValue = true;
-    callback(wdkService).then(
-      value => {
-        if (doSetValue) setValue(value);
-      },
-      error => {
-        if (doSetValue) {
-          wdkService.submitErrorIfNot500(error);
-          dispatch(notifyUnhandledError(error));
-        }
-      });
-    return () => { doSetValue = false; }
-  }, deps)
-  return value;
-}
+export const useWdkService = wdkServiceHookFactory(false);
+
+/**
+ * Works as "useWdkService" does, save it returns a value of
+ * "undefined" whenever the "callback" is invoked
+ * @param callback Returns a Promise whose resolved value is used
+ *                 as the return value of this hook.
+ */
+export const useWdkServiceWithRefresh = wdkServiceHookFactory(true);


### PR DESCRIPTION
This PR introduces `useWdkServiceWithRefresh`, a variation of the `useWdkService` hook which returns `undefined` before each invocation of the service callback. This can be used to communicate to the invoking component that some kind of spinner/loading indicator should be rendered in-between re-invocations of the service callback.

(The need for this hook arises from a [recent Organism Filter bugfix](https://github.com/VEuPathDB/ApiCommonWebsite/pull/14). There, I refactored `OrganismFilter` to use `useWdkService` instead of `useWdkEffect` / `useState` to fetch/maintain the filter summary data, and needed to some way to tidily encapsulate "clear the organism counts whenever a new step is selected.")