### PR TITLE
Handle rejected promises which arise as part of question submission

### DIFF
--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -471,8 +471,8 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
             pagination: { offset: 0, numRecords: 1 }
           });
 
-          return from(answerPromise.then(
-            () => {
+          return from(answerPromise
+            .then(() => {
               const weightQueryParam = Number.isNaN(weight) ? DEFAULT_STEP_WEIGHT : weight;
               const queryString =
                 "searchName=" + searchName +
@@ -482,8 +482,9 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
                   .join("");
 
               return transitionToInternalPage("/web-services-help?" + queryString);
-            }
-          ));
+            })
+            .catch(error => reportSubmissionError(action.payload.searchName, error, services.wdkService))
+          );
         }
 
         // if noSummaryOnSingleRecord is true, do special logic
@@ -505,7 +506,7 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
             }
             return undefined;
           })
-          .then(singleRecord => {
+          .then((singleRecord): Action | Promise<Action> => {
             if (singleRecord != null) {
               const { question } = questionState;
               return transitionToInternalPage(`/record/${question.outputRecordClassName}/${singleRecord.id.map(p => p.value).join('/')}`);
@@ -522,7 +523,9 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
                     name: DEFAULT_STRATEGY_NAME
                 })
               );
-          }));
+          })
+          .catch(error => reportSubmissionError(action.payload.searchName, error, services.wdkService))
+        );
       }
 
       const strategyEntry = state$.value.strategies.strategies[submissionMetadata.strategyId];
@@ -563,7 +566,9 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
                 }
               )
             )
-          ));
+          )
+          .catch(error => reportSubmissionError(action.payload.searchName, error, services.wdkService))
+        );
       }
 
       return from(services.wdkService.createStep(newSearchStepSpec)
@@ -577,8 +582,10 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
               undefined
             )
           )
-        ));
-    }).catch(error => reportSubmissionError(action.payload.searchName, error, services.wdkService))
+        )
+        .catch(error => reportSubmissionError(action.payload.searchName, error, services.wdkService))
+      );
+    });
   }),
   mergeAll()
 )

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -417,7 +417,7 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
       return Promise.resolve(getValueFromState(ctx, questionState, services)).then(value => [ parameter, value ] as [ Parameter, string ])
     })).then(entries => {
       return entries.reduce((paramValues, [ parameter, value ]) => Object.assign(paramValues, { [parameter.name]: value }), {} as ParameterValues);
-    }).then((paramValues): Action | Observable<Action> => {
+    }).then((paramValues): Observable<Action> => {
       const { payload: { submissionMetadata } }: SubmitQuestionAction = action;
       const { question } = questionState;
 
@@ -458,7 +458,7 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
 
       if (submissionMetadata.type === 'submit-custom-form') {
         submissionMetadata.onStepSubmitted(services.wdkService, newSearchStepSpec);
-        return fulfillCreateStep(-1, Date.now());
+        return EMPTY;
       }
 
       if (submissionMetadata.type === 'create-strategy') {
@@ -505,7 +505,7 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
             }
             return undefined;
           })
-          .then((singleRecord): Action | Promise<Action> => {
+          .then(singleRecord => {
             if (singleRecord != null) {
               const { question } = questionState;
               return transitionToInternalPage(`/record/${question.outputRecordClassName}/${singleRecord.id.map(p => p.value).join('/')}`);


### PR DESCRIPTION
### Note ###

@dmfalke: If you can think of a more robust solution, and time doesn't permit a dialogue, please do feel free to commit to this PR or open one of your own.

I'd also welcome additional QA from @dmfalke and @aurreco-uga: https://jtlong.plasmodb.org/plasmo.jtlong/app. (Please disregard the unrelated 500 error when the page loads.)

### The issue ###

Currently, question form submission errors are handler by this `catch` handler, which is meant to handle all possible rejected promises which might occur in the course of submitting the form:

https://github.com/VEuPathDB/WDKClient/blob/master/Client/src/StoreModules/QuestionStoreModule.ts#L581

In particular, for validation errors, this handler will reenable the "submit" button and display the appropriate validation errors.

[A recent PR of mine](https://github.com/VEuPathDB/WDKClient/pull/53) "broke" this handler, causing us to regard validation errors as being "unhandled."

More specifically, as part of that PR, I refactored [this `then` handler](https://github.com/VEuPathDB/WDKClient/blob/master/Client/src/StoreModules/QuestionStoreModule.ts#L420-L581) so that it returns `Action | Observable<Action>` instead of a `Promise<Action>`. This means that the various "subpromises", such as [this one](https://github.com/VEuPathDB/WDKClient/blob/master/Client/src/StoreModules/QuestionStoreModule.ts#L553), are now considered "unhandled" when an error occurs within them.

### The fix ###

This PR resolves this issue by giving each "subpromise" in the body of that `then` handler a `catch` handler.

