### PR TITLE
New "requestReviseStep" action

### DIFF
--- a/Client/src/Actions/StrategyActions.ts
+++ b/Client/src/Actions/StrategyActions.ts
@@ -223,6 +223,11 @@ export const requestCombineWithStrategy = makeActionCreator(
     })
 );
 
+export const requestReviseStep = makeActionCreator(
+    'requestReviseStep',
+    (strategyId: number, stepId: number, stepSpec: PatchStepSpec, searchConfig: SearchConfig) => ({ strategyId, stepId, stepSpec, searchConfig })
+);
+
 export type Action = InferAction<
   | typeof cancelStrategyRequest
   | typeof requestCreateStrategy
@@ -260,5 +265,6 @@ export type Action = InferAction<
   | typeof fulfillDeleteStep
   | typeof requestCombineWithBasket
   | typeof requestCombineWithStrategy
+  | typeof requestReviseStep
   >
 

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -53,9 +53,9 @@ import { RootState } from 'wdk-client/Core/State/Types';
 import {
   requestCreateStrategy,
   requestPutStrategyStepTree,
+  requestReviseStep,
   requestUpdateStepProperties,
   requestUpdateStepSearchConfig,
-  fulfillCreateStep,
   fulfillCreateStrategy
 } from 'wdk-client/Actions/StrategyActions';
 import { addStep } from 'wdk-client/Utils/StrategyUtils';
@@ -432,16 +432,12 @@ const observeQuestionSubmit: QuestionEpic = (action$, state$, services) => actio
 
       if (submissionMetadata.type === 'edit-step') {
         return of(
-          requestUpdateStepProperties(
+          requestReviseStep(
             submissionMetadata.strategyId,
             submissionMetadata.stepId,
             {
               customName
-            }
-          ),
-          requestUpdateStepSearchConfig(
-            submissionMetadata.strategyId,
-            submissionMetadata.stepId,
+            },
             {
               ...submissionMetadata.previousSearchConfig,
               ...searchConfig

--- a/Client/src/StoreModules/StrategyStoreModule.ts
+++ b/Client/src/StoreModules/StrategyStoreModule.ts
@@ -690,5 +690,6 @@ async function getFulfillCombineWithStrategy(
     mrate([requestCreateStep], getFulfillCreateStep),
     mrate([requestCombineWithBasket], getFulfillCombineWithBasket),
     mrate([requestCombineWithStrategy], getFulfillCombineWithStrategy),
-    mrate([requestReviseStep], getFulfillStrategy_ReviseStep)
+    mrate([requestReviseStep], getFulfillStrategy_ReviseStep,
+      { areActionsNew: stubTrue })
   );


### PR DESCRIPTION
**Note:** Opening this as a draft PR since the initial implementation needs to be DRYed up before merge.

When submitting a "revise step" form, the latest logic is to dispatch `requestUpdateStepProperties` (to update the customName) and `requestUpdateStepSearchConfig` (to update the searchConfig). This is causing the form to close even if only one of the two updates succeeded.

This PR resolves the issue by introducing a `requestReviseStep` action with an associated `mrate` fulfiller which (1) tries to update the search config and then, if that succeeds, (2) tries to updates the step properties, and then, if both succeed, (3) dispatches the appropriate `fulfillStrategy` actions, or if at least one fails, (4) dispatches a `reportSubmissionError`.
