### PR TITLE
Prevent render when ownProps and data are out-of-sync.

### DIFF
--- a/Client/src/Controllers/RecordController.tsx
+++ b/Client/src/Controllers/RecordController.tsx
@@ -84,7 +84,8 @@ class RecordController extends PageController<Props> {
     return (
       this.props.recordClass != null &&
       this.props.record != null &&
-      !this.props.isLoading
+      !this.props.isLoading &&
+      this.props.ownProps.recordClass === this.props.recordClass.urlSegment
     );
   }
 


### PR DESCRIPTION
This can happen when going from one record type to another, and is
especially problematic when there is an intermediate non-record-page. In
this case, the initial render will use state from the previous page,
which will cause partial record requests to be made for the previous
record type. Since ownProps and data props are out of sync, requests can
contain fields incompatible with the record type.