### PR TITLE
When "edit"ing a (revisable) invalid step, go directly to the Revise Step form

### DIFF
--- a/Client/src/Views/Strategy/StepBoxes.tsx
+++ b/Client/src/Views/Strategy/StepBoxes.tsx
@@ -444,7 +444,7 @@ function SlotContent({
 }
 
 const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
-  const { isNested, areInputsValid, stepTree, deleteStep } = props;
+  const { isNested, areInputsValid, stepTree, deleteStep, showReviseForm } = props;
   const { step, color, primaryInput, secondaryInput } = stepTree;
 
   const [ isDetailVisible, setDetailVisibility ] = useState(false);
@@ -471,7 +471,11 @@ const stepBoxFactory = (isPreview: boolean) => (props: StepBoxProps) => {
     ? (
       <button
         type="button"
-        onClick={() => setDetailVisibility(true)}
+        onClick={
+          !step.validation.isValid && allowRevise
+            ? () => showReviseForm()
+            : () => setDetailVisibility(true)
+        }
         className={cx("--EditButton")}
       >
         <div style={{ fontSize: '.8em'}}>Edit</div>


### PR DESCRIPTION
Opening this as a draft PR so that @aurreco-uga can OK the UX first.

This PR adjusts the UX when the "edit" button of a revisable* invalid step is clicked: when this button is clicked, the Revise Step form modal is opened instead of the Step Details dialog.

\* Here, "revisable" means "can be revised via the Revise Step form modal" (as opposed to "inline" via the Step Details dialog).