### PR TITLE
Introduce new "shouldExpandOnClick" prop

### DIFF
--- a/Client/src/Components/CheckboxTree/CheckboxTree.tsx
+++ b/Client/src/Components/CheckboxTree/CheckboxTree.tsx
@@ -54,6 +54,9 @@ type Props<T> = {
   /** Whether to, on expanding a node, automatically expand its descendants with one child */
   shouldExpandDescendantsWithOneChild?: boolean;
 
+  /** Whether to expand a node if its contents are clicked */
+  shouldExpandOnClick?: boolean
+
   /** Whether to show the root node or start with the array of children; optional, defaults to false */
   showRoot?: boolean;
 
@@ -689,7 +692,7 @@ export default class CheckboxTree<T> extends Component<Props<T>, State<T>> {
       isSearchable, currentList, defaultList, showSearchBox, searchTerm,
       searchBoxPlaceholder, searchBoxHelp, searchIconName,
       linksPosition = LinksPosition.Both, additionalActions,
-      onSearchTermChange, autoFocusSearchBox
+      onSearchTermChange, autoFocusSearchBox, shouldExpandOnClick = true
     } = this.props;
     let topLevelNodes = (showRoot ? [ this.state.generated.statefulTree ] :
       getStatefulChildren(this.state.generated.statefulTree));
@@ -747,6 +750,7 @@ export default class CheckboxTree<T> extends Component<Props<T>, State<T>> {
               isActiveSearch={isActiveSearch(this.props)}
               toggleSelection={this.toggleSelection}
               toggleExpansion={this.toggleExpansion}
+              shouldExpandOnClick={shouldExpandOnClick}
               getNodeId={getNodeId}
               getNodeChildren={getStatefulChildren}
               renderNode={this.renderNode} />

--- a/Client/src/Components/CheckboxTree/CheckboxTreeNode.tsx
+++ b/Client/src/Components/CheckboxTree/CheckboxTreeNode.tsx
@@ -53,6 +53,7 @@ type Props<T> = {
   getNodeId: (node: T) => string;
   getNodeChildren: (node: T) => T[];
   renderNode: (node: T, path?: number[]) => React.ReactNode;
+  shouldExpandOnClick: boolean;
 }
 
 class CheckboxTreeNode<T> extends Component<Props<T>> {
@@ -79,7 +80,8 @@ class CheckboxTreeNode<T> extends Component<Props<T>> {
       toggleExpansion,
       getNodeId,
       getNodeChildren,
-      renderNode
+      renderNode,
+      shouldExpandOnClick
     } = this.props;
 
     // We have to apply the generic type `T` to these child components. This is
@@ -112,7 +114,10 @@ class CheckboxTreeNode<T> extends Component<Props<T>> {
             />
           )}
           {!isSelectable || (!isMultiPick && !isLeafNode) ? (
-            <div className="wdk-CheckboxTreeNodeContent" onClick={this.toggleExpansion}>
+            <div
+              className="wdk-CheckboxTreeNodeContent"
+              onClick={shouldExpandOnClick ? this.toggleExpansion : undefined}
+            >
               {nodeElement}
             </div>
           ) : (
@@ -152,6 +157,7 @@ class CheckboxTreeNode<T> extends Component<Props<T>> {
                 isActiveSearch={isActiveSearch}
                 toggleSelection={toggleSelection}
                 toggleExpansion={toggleExpansion}
+                shouldExpandOnClick={shouldExpandOnClick}
                 getNodeId={getNodeId}
                 getNodeChildren={getNodeChildren}
                 renderNode={renderNode} />


### PR DESCRIPTION
This PR introduces a new `shouldExpandOnClick` prop for our checkbox tree, which is set to `true` by default.

When `shouldExpandOnClick` is set to `false`, clicking on a node's contents will not trigger an expansion. This behavior is useful for checkbox trees whose nodes have some kind of click-activated controls, such as the "constraint" checkbox trees found in genomics sites' `GenesByOrthologPattern` and OrthoMCL's `GroupsByPhyleticPattern`. In these cases, it is undesirable for nodes to be expanded/collapsed when they are clicked.

(The [current implementation of `GenesByOrthologPattern` circumvents this issue by using stopPropagation](https://github.com/VEuPathDB/ApiCommonWebsite/blob/dadfba80ec2c5303738bb6d1c0caadd6467b396e/Site/webapp/wdkCustomization/js/client/components/questions/GenesByOrthologPattern.tsx#L289), which is an anti-pattern.)