### PR TITLE
New "Param Value Store" WDK Client Dependency

### DIFF
--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -7,7 +7,6 @@ import {
   SearchConfig
 } from 'wdk-client/Utils/WdkModel';
 import { AddType } from 'wdk-client/Views/Strategy/Types';
-import { alert } from 'wdk-client/Utils/Platform';
 import { NewStepSpec, Step } from 'wdk-client/Utils/WdkUser';
 import { WdkService } from 'wdk-client/Core';
 import { makeActionCreator } from 'wdk-client/Utils/ActionCreatorUtils';
@@ -16,7 +15,6 @@ import { makeActionCreator } from 'wdk-client/Utils/ActionCreatorUtils';
 export type Action =
   | UpdateActiveQuestionAction
   | QuestionLoadedAction
-  | ReloadQuestionAction
   | UnloadQuestionAction
   | QuestionErrorAction
   | QuestionNotFoundAction
@@ -92,22 +90,6 @@ export function questionLoaded(payload: QuestionLoadedAction['payload']): Questi
 }
 
 //==============================================================================
-
-export const RELOAD_QUESTION = 'question/reload-question';
-
-export interface ReloadQuestionAction {
-  type: typeof RELOAD_QUESTION;
-  payload: QuestionPayload<{
-    stepId: number | undefined;
-  }>;
-}
-
-export function reloadQuestion(payload: ReloadQuestionAction['payload']): ReloadQuestionAction {
-  return {
-    type: RELOAD_QUESTION,
-    payload
-  };
-}
 
 export const UNLOAD_QUESTION = 'question/unload-question';
 

--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -76,7 +76,7 @@ export interface QuestionLoadedAction {
     question: QuestionWithParameters;
     recordClass: RecordClass;
     paramValues: ParameterValues;
-    atLeastOneInitialParamValueProvided: boolean;
+    defaultParamValues: ParameterValues;
     initialParamData?: Record<string, string>;
     wdkWeight?: number;
     customName?: string;

--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -44,8 +44,9 @@ export interface UpdateActiveQuestionAction {
   type: typeof UPDATE_ACTIVE_QUESTION;
   payload: QuestionPayload<{
     autoRun: boolean;
+    prepopulateWithLastParamValues: boolean;
     initialParamData?: Record<string, string>;
-    stepId: number | undefined
+    stepId: number | undefined;
   }>
 }
 
@@ -70,6 +71,7 @@ export interface QuestionLoadedAction {
   type: typeof QUESTION_LOADED;
   payload: QuestionPayload<{
     autoRun: boolean;
+    prepopulateWithLastParamValues: boolean;
     question: QuestionWithParameters;
     recordClass: RecordClass;
     paramValues: ParameterValues;

--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -75,6 +75,7 @@ export interface QuestionLoadedAction {
     question: QuestionWithParameters;
     recordClass: RecordClass;
     paramValues: ParameterValues;
+    atLeastOneInitialParamValueProvided: boolean;
     initialParamData?: Record<string, string>;
     wdkWeight?: number;
     customName?: string;

--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -16,6 +16,7 @@ import { makeActionCreator } from 'wdk-client/Utils/ActionCreatorUtils';
 export type Action =
   | UpdateActiveQuestionAction
   | QuestionLoadedAction
+  | ReloadQuestionAction
   | UnloadQuestionAction
   | QuestionErrorAction
   | QuestionNotFoundAction
@@ -91,6 +92,22 @@ export function questionLoaded(payload: QuestionLoadedAction['payload']): Questi
 }
 
 //==============================================================================
+
+export const RELOAD_QUESTION = 'question/reload-question';
+
+export interface ReloadQuestionAction {
+  type: typeof RELOAD_QUESTION;
+  payload: QuestionPayload<{
+    stepId: number | undefined;
+  }>;
+}
+
+export function reloadQuestion(payload: ReloadQuestionAction['payload']): ReloadQuestionAction {
+  return {
+    type: RELOAD_QUESTION,
+    payload
+  };
+}
 
 export const UNLOAD_QUESTION = 'question/unload-question';
 

--- a/Client/src/Actions/QuestionActions.ts
+++ b/Client/src/Actions/QuestionActions.ts
@@ -52,6 +52,7 @@ export interface UpdateActiveQuestionAction {
 export function updateActiveQuestion(payload: {
   searchName: string;
   autoRun: boolean,
+  prepopulateWithLastParamValues: boolean,
   initialParamData?: Record<string, string>,
   stepId: number | undefined
 }): UpdateActiveQuestionAction {

--- a/Client/src/Controllers/LegacyParamController.tsx
+++ b/Client/src/Controllers/LegacyParamController.tsx
@@ -64,6 +64,7 @@ class LegacyParamController extends ViewController<Props> {
       this.props.mapped.eventHandlers.setActiveQuestion({
         searchName: this.props.own.searchName,
         autoRun: false,
+        prepopulateWithLastParamValues: false,
         initialParamData: this.props.own.paramValues,
         stepId: this.props.own.stepId
       });

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -233,14 +233,15 @@ function useResetFormConfig(
 
   return useMemo(
     () => (
-      prepopulateWithLastParamValues && atLeastOneInitialParamValueProvided
+      prepopulateWithLastParamValues
         ? {
             offered: true,
+            disabled: !atLeastOneInitialParamValueProvided,
             onResetForm: reloadFormWithSystemDefaults,
             resetFormContent: (
               <React.Fragment>
                 <IconAlt fa="refresh" />
-                Reset form with default parameters
+                Reset values
               </React.Fragment>
             )
           }

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -242,9 +242,7 @@ function useResetFormConfig(
             resetFormContent: (
               <React.Fragment>
                 <IconAlt fa="refresh" />
-                {' '}
                 Reload form with default parameters
-                {' '}
                 <IconAlt fa="refresh" />
               </React.Fragment>
             )

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -10,8 +10,7 @@ import {
   updateActiveQuestion,
   updateParamValue,
   changeGroupVisibility,
-  SubmissionMetadata,
-  submitQuestion
+  SubmissionMetadata
 } from 'wdk-client/Actions/QuestionActions';
 import { QuestionState } from 'wdk-client/StoreModules/QuestionStoreModule';
 import Error from 'wdk-client/Components/PageStatus/Error';
@@ -191,6 +190,7 @@ function QuestionController(props: Props) {
         submissionMetadata={submissionMetadata}
         submitButtonText={submitButtonText}
         recordClass={recordClass}
+        resetFormConfig={{ offered: false }}
       />
     : <DefaultRenderForm
         parameterElements={parameterElements}
@@ -200,6 +200,7 @@ function QuestionController(props: Props) {
         submissionMetadata={submissionMetadata}
         submitButtonText={submitButtonText}
         recordClass={recordClass}
+        resetFormConfig={{ offered: false }}
       />;
 }
 

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -9,9 +9,10 @@ import { Plugin } from 'wdk-client/Utils/ClientPlugin';
 import {
   Action,
   SubmissionMetadata,
+  changeGroupVisibility,
+  reloadQuestion,
   updateActiveQuestion,
-  updateParamValue,
-  changeGroupVisibility
+  updateParamValue
 } from 'wdk-client/Actions/QuestionActions';
 import { QuestionState } from 'wdk-client/StoreModules/QuestionStoreModule';
 import Error from 'wdk-client/Components/PageStatus/Error';
@@ -25,7 +26,7 @@ const ActionCreators = {
   setGroupVisibility: changeGroupVisibility
 }
 
-type OwnProps = { 
+export type OwnProps = {
   question: string, 
   recordClass: string, 
   FormComponent?: (props: FormProps) => JSX.Element, 
@@ -135,10 +136,9 @@ function QuestionController(props: Props) {
 
   const resetFormConfig = useResetFormConfig(
     searchName,
-    autoRun,
+    state.stepId,
     prepopulateWithLastParamValues,
     state.atLeastOneInitialParamValueProvided,
-    state.stepId,
     dispatch
   );
   
@@ -216,23 +216,19 @@ function QuestionController(props: Props) {
 
 function useResetFormConfig(
   searchName: string,
-  autoRun: boolean,
+  stepId: number | undefined,
   prepopulateWithLastParamValues: boolean,
   atLeastOneInitialParamValueProvided: boolean,
-  stepId: number | undefined,
   dispatch: Dispatch<Action>
 ): ResetFormConfig {
   const reloadFormWithSystemDefaults = useCallback(
     () => {
-      dispatch(updateActiveQuestion({
-        autoRun,
+      dispatch(reloadQuestion({
         searchName,
-        prepopulateWithLastParamValues: false,
-        initialParamData: {},
         stepId
       }));
     },
-    [ autoRun, dispatch, searchName, stepId ]
+    [ searchName, stepId ]
   );
 
   return useMemo(

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -242,8 +242,7 @@ function useResetFormConfig(
             resetFormContent: (
               <React.Fragment>
                 <IconAlt fa="refresh" />
-                Reload form with default parameters
-                <IconAlt fa="refresh" />
+                Reset form with default parameters
               </React.Fragment>
             )
           }

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -10,7 +10,6 @@ import {
   Action,
   SubmissionMetadata,
   changeGroupVisibility,
-  reloadQuestion,
   updateActiveQuestion,
   updateParamValue
 } from 'wdk-client/Actions/QuestionActions';
@@ -225,8 +224,11 @@ function useResetFormConfig(
 ): ResetFormConfig {
   const reloadFormWithSystemDefaults = useCallback(
     () => {
-      dispatch(reloadQuestion({
+      dispatch(updateActiveQuestion({
+        autoRun: false,
         searchName,
+        prepopulateWithLastParamValues: false,
+        initialParamData: {},
         stepId
       }));
     },

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -50,7 +50,12 @@ type OwnProps = {
    * directed to the new strategy. Any errors will appear above the search form
    * and the user will be able to correct the errors.
    */
-  autoRun?: boolean
+  autoRun?: boolean,
+  /**
+   * If true, the form will be prepopulated with the param value
+   * selections from the user's last visit to the form
+   */
+  prepopulateWithLastParamValues?: boolean
 };
 type StateProps = QuestionState & { recordClasses: GlobalData['recordClasses'] };
 type DispatchProps = { eventHandlers: typeof ActionCreators, dispatch: Dispatch };
@@ -62,7 +67,8 @@ type Props = DispatchProps & StateProps & {
   submitButtonText?: string,
   shouldChangeDocumentTitle?: boolean,
   initialParamData?: Record<string, string>,
-  autoRun: boolean;
+  autoRun: boolean,
+  prepopulateWithLastParamValues: boolean
 };
 
 function QuestionController(props: Props) {
@@ -78,6 +84,7 @@ function QuestionController(props: Props) {
     shouldChangeDocumentTitle, 
     initialParamData,
     autoRun,
+    prepopulateWithLastParamValues,
     ...state } = props;
   const stepId = submissionMetadata.type === 'edit-step' || submissionMetadata.type === 'submit-custom-form' ? submissionMetadata.stepId : undefined;
 
@@ -106,6 +113,7 @@ function QuestionController(props: Props) {
       searchName,
       autoRun,
       initialParamData: autoRun && initialParamData == null ? {} : initialParamData,
+      prepopulateWithLastParamValues,
       stepId
     }))
   }, [searchName, stepId]);
@@ -239,7 +247,8 @@ const enhance = connect<StateProps, DispatchProps, OwnProps, Props, RootState>(
     submitButtonText: ownProps.submitButtonText,
     shouldChangeDocumentTitle: ownProps.shouldChangeDocumentTitle,
     initialParamData: ownProps.initialParamData,
-    autoRun: ownProps.autoRun === true
+    autoRun: ownProps.autoRun === true,
+    prepopulateWithLastParamValues: ownProps.prepopulateWithLastParamValues === true
   })
 )
 

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -137,6 +137,7 @@ function QuestionController(props: Props) {
     searchName,
     autoRun,
     prepopulateWithLastParamValues,
+    state.atLeastOneInitialParamValueProvided,
     state.stepId,
     dispatch
   );
@@ -217,6 +218,7 @@ function useResetFormConfig(
   searchName: string,
   autoRun: boolean,
   prepopulateWithLastParamValues: boolean,
+  atLeastOneInitialParamValueProvided: boolean,
   stepId: number | undefined,
   dispatch: Dispatch<Action>
 ): ResetFormConfig {
@@ -235,7 +237,7 @@ function useResetFormConfig(
 
   return useMemo(
     () => (
-      prepopulateWithLastParamValues
+      prepopulateWithLastParamValues && atLeastOneInitialParamValueProvided
         ? {
             offered: true,
             onResetForm: reloadFormWithSystemDefaults,
@@ -250,7 +252,11 @@ function useResetFormConfig(
             offered: false
           }
     ),
-    [ prepopulateWithLastParamValues ]
+    [
+      prepopulateWithLastParamValues,
+      atLeastOneInitialParamValueProvided,
+      reloadFormWithSystemDefaults
+    ]
   );
 };
 

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -225,12 +225,12 @@ function useResetFormConfig(
       dispatch(updateActiveQuestion({
         autoRun,
         searchName,
-        prepopulateWithLastParamValues,
-        initialParamData: undefined,
+        prepopulateWithLastParamValues: false,
+        initialParamData: {},
         stepId
       }));
     },
-    [ autoRun, dispatch, prepopulateWithLastParamValues, searchName, stepId ]
+    [ autoRun, dispatch, searchName, stepId ]
   );
 
   return useMemo(

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -1,4 +1,4 @@
-import { mapValues } from 'lodash';
+import { isEqual, mapValues } from 'lodash';
 import React, { useEffect, useCallback, FunctionComponent, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch, bindActionCreators } from 'redux';
@@ -19,7 +19,7 @@ import Error from 'wdk-client/Components/PageStatus/Error';
 import NotFound from 'wdk-client/Views/NotFound/NotFound';
 import { Props as FormProps, ResetFormConfig } from 'wdk-client/Views/Question/DefaultQuestionForm';
 import { GlobalData } from 'wdk-client/StoreModules/GlobalData';
-import { RecordClass, Question } from 'wdk-client/Utils/WdkModel';
+import { ParameterValues, RecordClass, Question } from 'wdk-client/Utils/WdkModel';
 
 const ActionCreators = {
   updateParamValue,
@@ -138,7 +138,8 @@ function QuestionController(props: Props) {
     searchName,
     state.stepId,
     prepopulateWithLastParamValues,
-    state.atLeastOneInitialParamValueProvided,
+    state.paramValues,
+    state.defaultParamValues,
     dispatch
   );
   
@@ -218,7 +219,8 @@ function useResetFormConfig(
   searchName: string,
   stepId: number | undefined,
   prepopulateWithLastParamValues: boolean,
-  atLeastOneInitialParamValueProvided: boolean,
+  paramValues: ParameterValues,
+  defaultParamValues: ParameterValues,
   dispatch: Dispatch<Action>
 ): ResetFormConfig {
   const reloadFormWithSystemDefaults = useCallback(
@@ -236,7 +238,10 @@ function useResetFormConfig(
       prepopulateWithLastParamValues
         ? {
             offered: true,
-            disabled: !atLeastOneInitialParamValueProvided,
+            disabled: isEqual(
+              defaultParamValues,
+              paramValues
+            ),
             onResetForm: reloadFormWithSystemDefaults,
             resetFormContent: (
               <React.Fragment>
@@ -250,8 +255,9 @@ function useResetFormConfig(
           }
     ),
     [
+      defaultParamValues,
+      paramValues,
       prepopulateWithLastParamValues,
-      atLeastOneInitialParamValueProvided,
       reloadFormWithSystemDefaults
     ]
   );

--- a/Client/src/Core/Root.tsx
+++ b/Client/src/Core/Root.tsx
@@ -11,10 +11,10 @@ import Page from 'wdk-client/Components/Layout/Page';
 import { Store } from 'redux';
 import { Provider } from 'react-redux';
 import { RouteEntry } from 'wdk-client/Core/RouteEntry';
-import WdkService, { WdkServiceContext } from 'wdk-client/Service/WdkService';
 import WdkRoute from 'wdk-client/Core/WdkRoute';
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
 import UnhandledErrorsController from 'wdk-client/Controllers/UnhandledErrorsController';
+import { WdkDependencies, WdkDepdendenciesContext } from 'wdk-client/Hooks/WdkDependenciesEffect';
 
 type Props = {
   rootUrl: string,
@@ -23,7 +23,7 @@ type Props = {
   onLocationChange: (location: Location) => void,
   history: History,
   store: Store,
-  wdkService: WdkService,
+  wdkDependencies: WdkDependencies,
   staticContent?: string
 };
 
@@ -106,7 +106,7 @@ export default class Root extends React.Component<Props, State> {
       <Provider store={this.props.store}>
         <ErrorBoundary>
           <Router history={this.props.history}>
-            <WdkServiceContext.Provider value={this.props.wdkService}>
+            <WdkDepdendenciesContext.Provider value={this.props.wdkDependencies}>
               <PluginContext.Provider value={makeCompositePluginComponent(this.props.pluginConfig)}>
                 <Page classNameModifier={rootClassNameModifier}>
                   {staticContent ? safeHtml(staticContent, null, 'div') : (
@@ -129,7 +129,7 @@ export default class Root extends React.Component<Props, State> {
                   )}
                 </Page>
               </PluginContext.Provider>
-            </WdkServiceContext.Provider>
+            </WdkDepdendenciesContext.Provider>
           </Router>
         </ErrorBoundary>
       </Provider>

--- a/Client/src/Core/Store.ts
+++ b/Client/src/Core/Store.ts
@@ -1,8 +1,9 @@
 import { compose, mapKeys, mapValues, values } from 'lodash/fp';
 import { applyMiddleware, combineReducers, createStore, Reducer, Middleware, Action } from 'redux';
 import { combineEpics, createEpicMiddleware, Epic } from 'redux-observable';
-import { EMPTY, of, Observable } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
 import { PageTransitioner } from 'wdk-client/Utils/PageTransitioner';
+import { ParamValueStore } from 'wdk-client/Utils/ParamValueStore';
 import WdkService from 'wdk-client/Service/WdkService';
 import { wdkMiddleware } from 'wdk-client/Core/WdkMiddleware';
 import { catchError, startWith } from 'rxjs/operators';
@@ -15,8 +16,9 @@ declare global{
 }
 
 export type EpicDependencies = {
-  wdkService: WdkService;
+  paramValueStore: ParamValueStore;
   transitioner: PageTransitioner;
+  wdkService: WdkService;
 }
 export type ModuleReducer<T, A extends Action> = (state: T | undefined, action: A) => T;
 export type ModuleEpic<T, A extends Action> = Epic<A, A, T, EpicDependencies>;
@@ -35,15 +37,16 @@ type RootReducer<T, A extends Action> = Reducer<T, A>;
 
 export function createWdkStore<T, A extends Action>(
   storeModules: StoreModuleRecord<T, A>,
-  wdkService: WdkService,
+  paramValueStore: ParamValueStore,
   transitioner: PageTransitioner,
+  wdkService: WdkService,
   // FIXME Figure out how to allow the order of middleware to be configured
   additionalMiddleware: Middleware[] = []
 ) {
   const rootReducer = makeRootReducer(storeModules);
   const rootEpic = makeRootEpic(storeModules);
   const epicMiddleware = createEpicMiddleware<A, A, T, EpicDependencies>({
-    dependencies: { wdkService, transitioner }
+    dependencies: { paramValueStore, transitioner, wdkService }
   });
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__

--- a/Client/src/Core/Store.ts
+++ b/Client/src/Core/Store.ts
@@ -1,4 +1,4 @@
-import { compose, mapKeys, mapValues, values } from 'lodash/fp';
+import { compose, mapKeys, mapValues, omit, values } from 'lodash/fp';
 import { applyMiddleware, combineReducers, createStore, Reducer, Middleware, Action } from 'redux';
 import { combineEpics, createEpicMiddleware, Epic } from 'redux-observable';
 import { EMPTY, Observable } from 'rxjs';
@@ -37,16 +37,14 @@ type RootReducer<T, A extends Action> = Reducer<T, A>;
 
 export function createWdkStore<T, A extends Action>(
   storeModules: StoreModuleRecord<T, A>,
-  paramValueStore: ParamValueStore,
-  transitioner: PageTransitioner,
-  wdkService: WdkService,
+  dependencies: EpicDependencies,
   // FIXME Figure out how to allow the order of middleware to be configured
   additionalMiddleware: Middleware[] = []
 ) {
   const rootReducer = makeRootReducer(storeModules);
   const rootEpic = makeRootEpic(storeModules);
   const epicMiddleware = createEpicMiddleware<A, A, T, EpicDependencies>({
-    dependencies: { paramValueStore, transitioner, wdkService }
+    dependencies
   });
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
@@ -58,7 +56,7 @@ export function createWdkStore<T, A extends Action>(
   const enhancer = composeEnhancers(
     applyMiddleware(
       ...additionalMiddleware,
-      wdkMiddleware({ wdkService, transitioner }),
+      wdkMiddleware(dependencies),
       epicMiddleware,
     )
   );

--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -11,6 +11,7 @@ import * as Components from 'wdk-client/Components';
 import { ClientPluginRegistryEntry } from 'wdk-client/Utils/ClientPlugin'; // eslint-disable-line no-unused-vars
 import { createMockHistory } from 'wdk-client/Utils/MockHistory';
 import { getTransitioner } from 'wdk-client/Utils/PageTransitioner';
+import { getInstance as getParamValueStoreInstance } from 'wdk-client/Utils/ParamValueStore';
 import { getInstance } from 'wdk-client/Service/WdkService';
 import { updateLocation } from 'wdk-client/Actions/RouterActions';
 import { loadAllStaticData } from 'wdk-client/Actions/StaticDataActions';
@@ -71,6 +72,7 @@ export function initialize(options) {
     ? createBrowserHistory({ basename: rootUrl })
     : createMockHistory({ basename: rootUrl });
   let wdkService = wrapWdkService(getInstance(endpoint));
+  let paramValueStore = getParamValueStoreInstance(endpoint, wdkService);
   let transitioner = getTransitioner(history);
   let store = createWdkStore(wrapStoreModules(storeModules), wdkService, transitioner, additionalMiddleware);
 
@@ -106,7 +108,7 @@ export function initialize(options) {
   });
 
   // return WDK application components
-  return { wdkService, store, history, pluginConfig };
+  return { wdkService, paramValueStore, store, history, pluginConfig };
 }
 
 /**

--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -74,11 +74,16 @@ export function initialize(options) {
   let wdkService = wrapWdkService(getInstance(endpoint));
   let paramValueStore = getParamValueStoreInstance(endpoint, wdkService);
   let transitioner = getTransitioner(history);
-  let store = createWdkStore(
-    wrapStoreModules(storeModules),
+
+  let wdkDependencies = {
     paramValueStore,
     transitioner,
-    wdkService,
+    wdkService
+  };
+
+  let store = createWdkStore(
+    wrapStoreModules(storeModules),
+    wdkDependencies,
     additionalMiddleware
   );
 
@@ -103,11 +108,7 @@ export function initialize(options) {
           pluginConfig: pluginConfig.concat(defaultPluginConfig),
           routes: wrapRoutes(wdkRoutes),
           onLocationChange: handleLocationChange,
-          wdkDependencies: {
-            paramValueStore,
-            transitioner,
-            wdkService
-          },
+          wdkDependencies,
           staticContent: retainContainerContent ? container.innerHTML : undefined
         });
       ReactDOM.render(applicationElement, container);

--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -103,7 +103,11 @@ export function initialize(options) {
           pluginConfig: pluginConfig.concat(defaultPluginConfig),
           routes: wrapRoutes(wdkRoutes),
           onLocationChange: handleLocationChange,
-          wdkService,
+          wdkDependencies: {
+            paramValueStore,
+            transitioner,
+            wdkService
+          },
           staticContent: retainContainerContent ? container.innerHTML : undefined
         });
       ReactDOM.render(applicationElement, container);

--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -74,7 +74,13 @@ export function initialize(options) {
   let wdkService = wrapWdkService(getInstance(endpoint));
   let paramValueStore = getParamValueStoreInstance(endpoint, wdkService);
   let transitioner = getTransitioner(history);
-  let store = createWdkStore(wrapStoreModules(storeModules), wdkService, transitioner, additionalMiddleware);
+  let store = createWdkStore(
+    wrapStoreModules(storeModules),
+    paramValueStore,
+    transitioner,
+    wdkService,
+    additionalMiddleware
+  );
 
   // load static WDK data into service cache and view stores that need it
   loadAllStaticData(wdkService, store.dispatch);

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -75,7 +75,6 @@ const routes: RouteEntry[] = [
           }}
           pluginProps={{
             ...props.match.params,
-            hash: props.location.hash.slice(1),
             submissionMetadata: {
               type: 'create-strategy'
             } as const,

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -18,14 +18,12 @@ import UserPasswordChangeController from 'wdk-client/Controllers/UserPasswordCha
 import UserPasswordResetController from 'wdk-client/Controllers/UserPasswordResetController';
 import UserMessageController from 'wdk-client/Controllers/UserMessageController';
 import SiteMapController from 'wdk-client/Controllers/SiteMapController';
-import UserDatasetListController from 'wdk-client/Controllers/UserDatasetListController';
 import UserDatasetDetailController from 'wdk-client/Controllers/UserDatasetDetailController';
 import FavoritesController from 'wdk-client/Controllers/FavoritesController';
 import UserCommentFormController from 'wdk-client/Controllers/UserCommentFormController';
 import UserCommentShowController from 'wdk-client/Controllers/UserCommentShowController';
 import UserLoginController from 'wdk-client/Controllers/UserLoginController';
-import UserDatasetNewUploadController from 'wdk-client/Controllers/UserDatasetNewUploadController';
-import UserDatasetAllUploadsController from 'wdk-client/Controllers/UserDatasetAllUploadsController';
+import QuestionController from 'wdk-client/Controllers/QuestionController';
 
 import { Plugin } from 'wdk-client/Utils/ClientPlugin';
 import StrategyWorkspaceController from 'wdk-client/Controllers/StrategyWorkspaceController';
@@ -80,11 +78,13 @@ const routes: RouteEntry[] = [
             hash: props.location.hash.slice(1),
             submissionMetadata: {
               type: 'create-strategy'
-            },
+            } as const,
             shouldChangeDocumentTitle: true,
             initialParamData,
-            autoRun: autoRun === '' || autoRun === 'true' || autoRun === '1'
+            autoRun: autoRun === '' || autoRun === 'true' || autoRun === '1',
+            prepopulateWithLastParamValues: true
           }}
+          defaultComponent={QuestionController}
         />
       );
     }

--- a/Client/src/Hooks/WdkDependenciesEffect.ts
+++ b/Client/src/Hooks/WdkDependenciesEffect.ts
@@ -1,0 +1,26 @@
+import React, { DependencyList, useContext, useEffect } from 'react';
+
+import { EpicDependencies } from 'wdk-client/Core/Store';
+
+export type WdkDependencies = EpicDependencies;
+
+// Identical to React.EffectCallback, save that the callback receives WdkService as a parameter
+export type DepEffectCallback<T> = ((dep: T) => void) | ((dep: T) => void | undefined);
+
+// FIXME Figure out a way to make the context type WdkDependencies (as opposed to WdkDependencies | undefined)
+// FIXME One approach would be to create the context in main.js
+export const WdkDepdendenciesContext = React.createContext<WdkDependencies | undefined>(undefined);
+
+export type WdkDependenciesEffectCallback = DepEffectCallback<WdkDependencies>;
+
+export const useWdkDependenciesEffect = (effect: WdkDependenciesEffectCallback, deps?: DependencyList): void => {
+  const wdkDependencies = useContext(WdkDepdendenciesContext);
+
+  useEffect(() => {
+    if (wdkDependencies == null) {
+      throw new Error('useWdkDependenciesEffect requires WdkDependencies to be provided via React context');
+    }
+
+    return effect(wdkDependencies);
+  }, deps);
+};

--- a/Client/src/Hooks/WdkDependenciesEffect.ts
+++ b/Client/src/Hooks/WdkDependenciesEffect.ts
@@ -4,7 +4,7 @@ import { EpicDependencies } from 'wdk-client/Core/Store';
 
 export type WdkDependencies = EpicDependencies;
 
-// Identical to React.EffectCallback, save that the callback receives WdkService as a parameter
+// Identical to React.EffectCallback, save that the callback receives one dependency as a parameter
 export type DepEffectCallback<T> = ((dep: T) => void) | ((dep: T) => void | undefined);
 
 // FIXME Figure out a way to make the context type WdkDependencies (as opposed to WdkDependencies | undefined)

--- a/Client/src/Service/ServiceBase.ts
+++ b/Client/src/Service/ServiceBase.ts
@@ -7,7 +7,7 @@ import * as Decode from 'wdk-client/Utils/Json';
 import { alert } from 'wdk-client/Utils/Platform';
 import { pendingPromise } from 'wdk-client/Utils/PromiseUtils';
 import { ServiceError } from 'wdk-client/Service/ServiceError';
-import { Question, RecordClass,} from 'wdk-client/Utils/WdkModel';
+import { Question } from 'wdk-client/Utils/WdkModel';
 import { keyBy } from 'lodash';
 import { expandedRecordClassDecoder } from 'wdk-client/Service/Decoders/RecordClassDecoders';
 
@@ -94,7 +94,7 @@ export const ServiceBase = (serviceUrl: string) => {
     name: 'WdkService/' + serviceUrl
   });
   const _cache: Map<string, Promise<any>> = new Map;
-  let _initialCheck: Promise<void> | undefined;
+  let _initialCheck: Promise<number> | undefined;
   let _version: number | undefined;
   let _isInvalidating = false;
 
@@ -265,7 +265,7 @@ export const ServiceBase = (serviceUrl: string) => {
       })
       .then(serviceConfig => {
         _version = serviceConfig.startupTime;
-        return undefined;
+        return _version;
       })
     }
     return _initialCheck;
@@ -273,6 +273,10 @@ export const ServiceBase = (serviceUrl: string) => {
 
   function _clearCache() {
     return _store.clear();
+  }
+
+  function getVersion() {
+    return _checkStoreVersion();
   }
 
   function getRecordTypesPath() {
@@ -364,6 +368,7 @@ export const ServiceBase = (serviceUrl: string) => {
     submitError,
     submitErrorIfNot500,
     getConfig,
+    getVersion,
     getRecordClasses,
     findRecordClass,
     getQuestions,

--- a/Client/src/Service/WdkService.ts
+++ b/Client/src/Service/WdkService.ts
@@ -1,27 +1,20 @@
+import { DependencyList } from 'react';
+
 import { memoize } from 'lodash';
-import React, { useContext, useEffect } from 'react';
+
+import { DepEffectCallback, useWdkDependenciesEffect } from 'wdk-client/Hooks/WdkDependenciesEffect';
 import { composeMixins, CompositeService as WdkService } from 'wdk-client/Service/ServiceMixins';
 
 export default WdkService;
 
-// Identical to React.EffectCallback, save that the callback receives WdkService as a parameter
-export type WdkEffectCallback = ((wdkService: WdkService) => void) | ((wdkService: WdkService) => void | undefined);
+export type WdkEffectCallback = DepEffectCallback<WdkService>;
 
 // Memoize based on serviceUrl, so that we only create one instance per
 // serviceUrl. This will ensure that multiple caches are not created.
 export const getInstance = memoize(composeMixins);
 
-// FIXME Figure out a way to make the context type WdkService (as opposed to WdkService | undefined)
-export const WdkServiceContext = React.createContext<WdkService | undefined>(undefined);
-
-export const useWdkEffect = (effect: WdkEffectCallback, deps?: any[]): void => {
-  const wdkService = useContext(WdkServiceContext);
-
-  useEffect(() => {
-    if (!wdkService) {
-      throw new Error('useWdkEffect requires a WdkService to be provided via React context');
-    }
-
+export const useWdkEffect = (effect: WdkEffectCallback, deps?: DependencyList): void => {
+  useWdkDependenciesEffect(({ wdkService }) => {
     return effect(wdkService);
   }, deps);
 };

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -388,7 +388,7 @@ const observeLoadQuestionSuccess: QuestionEpic = (action$) => action$.pipe(
 
 const observeUpdateParams: QuestionEpic = (action$, state$, { paramValueStore }) => action$.pipe(
   ofType<UpdateParamValueAction>(UPDATE_PARAM_VALUE),
-  mergeMap((action: UpdateParamValueAction) => {
+  mergeMap(async (action: UpdateParamValueAction) => {
     const searchName = action.payload.searchName;
     const questionState = state$.value.question.questions[searchName];
 
@@ -398,11 +398,12 @@ const observeUpdateParams: QuestionEpic = (action$, state$, { paramValueStore })
 
     const newParamValues = questionState.paramValues;
 
-    updateLastParamValues(paramValueStore, searchName, newParamValues);
+    await updateLastParamValues(paramValueStore, searchName, newParamValues);
 
     return EMPTY;
-  })
-)
+  }),
+  mergeAll()
+);
 
 const observeUpdateDependentParams: QuestionEpic = (action$, state$, { wdkService }) => action$.pipe(
   ofType<UpdateParamValueAction>(UPDATE_PARAM_VALUE),
@@ -680,7 +681,7 @@ async function loadQuestion(
     const wdkWeight = step == null ? undefined : step.searchConfig.wdkWeight;
 
     if (atLeastOneInitialParamValueProvided) {
-      updateLastParamValues(paramValueStore, searchName, paramValues);
+      await updateLastParamValues(paramValueStore, searchName, paramValues);
     }
 
     return questionLoaded({

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -635,7 +635,7 @@ async function loadQuestion(
   initialParamData?: Record<string, string>,
 ) {
   const step = stepId ? await wdkService.findStep(stepId) : undefined;
-  const initialParams = step ? initialParamDataFromStep(step) : initialParamData != null ? initialParamDataWithDatasetParamSpecialCase(initialParamData) : {};
+  const initialParams = await fetchInitialParams(step, initialParamData);
 
   try {
     const question = Object.keys(initialParams).length > 0
@@ -666,6 +666,16 @@ async function loadQuestion(
 
 function makeParamValuesStoreContext(searchName: string) {
   return `question-form/${searchName}`;
+}
+
+async function fetchInitialParams(step: Step | undefined, initialParamData: ParameterValues | undefined) {
+  if (step != null) {
+    return initialParamDataFromStep(step);
+  } else if (initialParamData != null) {
+    return initialParamDataWithDatasetParamSpecialCase(initialParamData);
+  } else {
+    return {};
+  }
 }
 
 function initialParamDataFromStep(step: Step): Record<string, string> {

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -652,6 +652,10 @@ async function loadQuestion(
     const paramValues = extractParamValues(question, initialParams, step);
 
     const wdkWeight = step == null ? undefined : step.searchConfig.wdkWeight;
+
+    const paramValuesStoreContext = makeParamValuesStoreContext(searchName);
+    paramValueStore.updateParamValues(paramValuesStoreContext, paramValues);
+
     return questionLoaded({
       autoRun,
       searchName,

--- a/Client/src/StoreModules/UserSessionStoreModule.ts
+++ b/Client/src/StoreModules/UserSessionStoreModule.ts
@@ -114,7 +114,7 @@ function observeShowLogoutWarning(
 
       if (!shouldLogout) return logoutDismissed();
 
-      paramValueStore.clearParamValues();
+      await paramValueStore.clearParamValues();
 
       const config = await wdkService.getConfig();
       const { oauthClientUrl, oauthUrl, method } = config.authentication;

--- a/Client/src/StoreModules/UserSessionStoreModule.ts
+++ b/Client/src/StoreModules/UserSessionStoreModule.ts
@@ -102,7 +102,7 @@ function observeSubmitLoginForm(
 function observeShowLogoutWarning(
   action$: ActionsObservable<Action>,
   state$: StateObservable<RootState>,
-  { wdkService }: EpicDependencies
+  { paramValueStore, wdkService }: EpicDependencies
 ): Observable<Action> {
   return action$.pipe(
     filter(showLogoutWarning.isOfType),
@@ -113,6 +113,8 @@ function observeShowLogoutWarning(
       );
 
       if (!shouldLogout) return logoutDismissed();
+
+      paramValueStore.clearParamValues();
 
       const config = await wdkService.getConfig();
       const { oauthClientUrl, oauthUrl, method } = config.authentication;

--- a/Client/src/Utils/Operations.tsx
+++ b/Client/src/Utils/Operations.tsx
@@ -13,7 +13,7 @@ import { CombineStepForm } from 'wdk-client/Views/Strategy/CombineStepForm';
 import { CombineWithStrategyForm } from 'wdk-client/Views/Strategy/CombineWithStrategyForm';
 import { ConvertStepForm } from 'wdk-client/Views/Strategy/ConvertStepForm';
 import { PartialUiStepTree } from 'wdk-client/Views/Strategy/Types';
-import { CombineOperator, IgnoreOperator } from 'wdk-client/Views/Strategy/StrategyUtils';
+import { BOOLEAN_OPERATOR_PARAM_NAME, CombineOperator, IgnoreOperator } from 'wdk-client/Views/Strategy/StrategyUtils';
 import { LeafPreview, BooleanPreview, TransformPreview } from 'wdk-client/Views/Strategy/StepBoxes';
 
 type OperatorMenuItem = {
@@ -78,7 +78,7 @@ export const defaultBinaryOperations: BinaryOperation[] = [
     },
     isOperationSearchName: searchName => searchName.startsWith('boolean_question'),
     baseClassName: 'CombineOperator',
-    operatorParamName: 'bq_operator',
+    operatorParamName: BOOLEAN_OPERATOR_PARAM_NAME,
     reviseOperatorParamConfiguration: { type: 'inline' },
     operatorMenuGroup: {
       name: 'standard_boolean_operators',

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -11,6 +11,8 @@ export interface ParamValueStore {
 
   fetchParamValues: (paramContext: string) => Promise<ParameterValues | null>;
 
+  removeParamValueEntry: (paramContext: string) => Promise<void>;
+
   updateParamValues: (
     paramContext: string,
     newParamValues: ParameterValues
@@ -51,6 +53,11 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
       const storeKey = makeParamStoreKey(paramContext);
 
       return _store.getItem(storeKey);
+    },
+    removeParamValueEntry: (paramContext: string) => {
+      const storeKey = makeParamStoreKey(paramContext);
+
+      return _store.removeItem(storeKey);
     },
     updateParamValues: async (paramContext, newParamValues) => {
       await _checkModelVersion();

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -9,14 +9,10 @@ type ParamValues = SearchConfig['parameters'];
 export interface ParamValueStore {
   clearParamValues: () => Promise<void>;
 
-  fetchParamValues: (
-    prefix: string | undefined,
-    parameterName: string
-  ) => Promise<ParamValues>;
+  fetchParamValues: (paramContext: string) => Promise<ParamValues>;
 
   updateParamValues: (
-    prefix: string | undefined,
-    parameterName: string,
+    paramContext: string,
     newParamValues: ParamValues
   ) => Promise<ParamValues>;
 }
@@ -32,22 +28,19 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
     clearParamValues: () => {
       return _store.clear();
     },
-    fetchParamValues: (prefix, parameterName) => {
-      const storeKey = makeStoreKey(prefix, parameterName);
+    fetchParamValues: paramContext => {
+      const storeKey = makeParamStoreKey(paramContext);
 
       return _store.getItem(storeKey);
     },
-    updateParamValues: (prefix, parameterName, newParamValues) => {
-      const storeKey = makeStoreKey(prefix, parameterName);
+    updateParamValues: (paramContext, newParamValues) => {
+      const storeKey = makeParamStoreKey(paramContext);
 
       return _store.setItem(storeKey, newParamValues);
     }
   };
 }
 
-function makeStoreKey(
-  prefix: string | undefined,
-  parameterName: string
-) {
-  return `${prefix ?? 'parameter'}/${parameterName}`;
+function makeParamStoreKey(paramContext: string) {
+  return `paramValues/${paramContext}`;
 }

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -2,19 +2,17 @@ import { memoize } from 'lodash';
 import localforage from 'localforage';
 
 import { WdkService } from 'wdk-client/Core';
-import { SearchConfig } from 'wdk-client/Utils/WdkModel';
-
-type ParamValues = SearchConfig['parameters'];
+import { ParameterValues } from 'wdk-client/Utils/WdkModel';
 
 export interface ParamValueStore {
   clearParamValues: () => Promise<void>;
 
-  fetchParamValues: (paramContext: string) => Promise<ParamValues>;
+  fetchParamValues: (paramContext: string) => Promise<ParameterValues>;
 
   updateParamValues: (
     paramContext: string,
-    newParamValues: ParamValues
-  ) => Promise<ParamValues>;
+    newParamValues: ParameterValues
+  ) => Promise<ParameterValues>;
 }
 
 export const getInstance = memoize(makeInstance, serviceUrl => serviceUrl);

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -6,7 +6,7 @@ import { SearchConfig } from 'wdk-client/Utils/WdkModel';
 
 type ParamValues = SearchConfig['parameters'];
 
-interface ParamValueStore {
+export interface ParamValueStore {
   clearParamValues: () => Promise<void>;
 
   fetchParamValues: (

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -25,7 +25,7 @@ interface ParamValueStore {
   ) => Promise<ParamValues>;
 }
 
-export const getInstance = memoize(makeInstance);
+export const getInstance = memoize(makeInstance, serviceUrl => serviceUrl);
 
 function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueStore {
   const _store = localforage.createInstance({

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -4,6 +4,8 @@ import localforage from 'localforage';
 import { WdkService } from 'wdk-client/Core';
 import { ParameterValues } from 'wdk-client/Utils/WdkModel';
 
+const MODEL_VERSION_STORE_KEY = '__version';
+
 export interface ParamValueStore {
   clearParamValues: () => Promise<void>;
 
@@ -22,16 +24,37 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
     name: `ParamValueStore/${serviceUrl}`
   });
 
+  function _fetchVersionNumber(): Promise<number | null> {
+    return _store.getItem(MODEL_VERSION_STORE_KEY);
+  }
+
+  async function _checkModelVersion(): Promise<number> {
+    const [ storeVersion, serviceVersion ] = await Promise.all([
+      _fetchVersionNumber(),
+      wdkService.getVersion()
+    ] as const);
+
+    if (storeVersion != null && storeVersion !== serviceVersion) {
+      await _store.clear();
+    }
+
+    return _store.setItem(MODEL_VERSION_STORE_KEY, serviceVersion);
+  }
+
   return {
     clearParamValues: () => {
       return _store.clear();
     },
-    fetchParamValues: paramContext => {
+    fetchParamValues: async paramContext => {
+      await _checkModelVersion();
+
       const storeKey = makeParamStoreKey(paramContext);
 
       return _store.getItem(storeKey);
     },
-    updateParamValues: (paramContext, newParamValues) => {
+    updateParamValues: async (paramContext, newParamValues) => {
+      await _checkModelVersion();
+
       const storeKey = makeParamStoreKey(paramContext);
 
       return _store.setItem(storeKey, newParamValues);

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -7,7 +7,7 @@ import { ParameterValues } from 'wdk-client/Utils/WdkModel';
 export interface ParamValueStore {
   clearParamValues: () => Promise<void>;
 
-  fetchParamValues: (paramContext: string) => Promise<ParameterValues>;
+  fetchParamValues: (paramContext: string) => Promise<ParameterValues | null>;
 
   updateParamValues: (
     paramContext: string,

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -1,0 +1,31 @@
+import { memoize, noop } from 'lodash';
+
+import { WdkService } from 'wdk-client/Core';
+import { SearchConfig } from 'wdk-client/Utils/WdkModel';
+
+type ParamValues = SearchConfig['parameters'];
+
+interface ParamValueStore {
+  clearParamValues: () =>  void;
+
+  fetchParamValues: (
+    recordClassUrlSegment: string,
+    searchUrlSegment: string
+  ) => Promise<ParamValues>;
+
+  updateParamValues: (
+    recordClassUrlSegment: string,
+    searchUrlSegment: string,
+    newParamValues: ParamValues
+  ) => void;
+}
+
+export const getInstance = memoize(makeInstance);
+
+function makeInstance(wdkService: WdkService): ParamValueStore {
+  return {
+    clearParamValues: noop,
+    fetchParamValues: () => Promise.resolve({}),
+    updateParamValues: noop
+  };
+}

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -11,17 +11,13 @@ interface ParamValueStore {
 
   fetchParamValues: (
     prefix: string | undefined,
-    recordClassUrlSegment: string,
-    searchUrlSegment: string,
-    parameterName: string,
+    parameterName: string
   ) => Promise<ParamValues>;
 
   updateParamValues: (
-    newParamValues: ParamValues,
     prefix: string | undefined,
-    recordClassUrlSegment: string,
-    searchUrlSegment: string,
-    parameterName: string
+    parameterName: string,
+    newParamValues: ParamValues
   ) => Promise<ParamValues>;
 }
 
@@ -36,13 +32,13 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
     clearParamValues: () => {
       return _store.clear();
     },
-    fetchParamValues: (...args) => {
-      const storeKey = makeStoreKey(...args);
+    fetchParamValues: (prefix, parameterName) => {
+      const storeKey = makeStoreKey(prefix, parameterName);
 
       return _store.getItem(storeKey);
     },
-    updateParamValues: (newParamValues, ...keyArgs) => {
-      const storeKey = makeStoreKey(...keyArgs);
+    updateParamValues: (prefix, parameterName, newParamValues) => {
+      const storeKey = makeStoreKey(prefix, parameterName);
 
       return _store.setItem(storeKey, newParamValues);
     }
@@ -51,9 +47,7 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
 
 function makeStoreKey(
   prefix: string | undefined,
-  recordClassUrlSegment: string,
-  searchUrlSegment: string,
   parameterName: string
 ) {
-  return `${prefix ?? 'parameter'}/${recordClassUrlSegment}/${searchUrlSegment}/${parameterName}`;
+  return `${prefix ?? 'parameter'}/${parameterName}`;
 }

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -1,4 +1,5 @@
-import { memoize, noop } from 'lodash';
+import { memoize } from 'lodash';
+import localforage from 'localforage';
 
 import { WdkService } from 'wdk-client/Core';
 import { SearchConfig } from 'wdk-client/Utils/WdkModel';
@@ -6,26 +7,53 @@ import { SearchConfig } from 'wdk-client/Utils/WdkModel';
 type ParamValues = SearchConfig['parameters'];
 
 interface ParamValueStore {
-  clearParamValues: () =>  void;
+  clearParamValues: () => Promise<void>;
 
   fetchParamValues: (
+    prefix: string | undefined,
     recordClassUrlSegment: string,
-    searchUrlSegment: string
+    searchUrlSegment: string,
+    parameterName: string,
   ) => Promise<ParamValues>;
 
   updateParamValues: (
+    newParamValues: ParamValues,
+    prefix: string | undefined,
     recordClassUrlSegment: string,
     searchUrlSegment: string,
-    newParamValues: ParamValues
-  ) => void;
+    parameterName: string
+  ) => Promise<ParamValues>;
 }
 
 export const getInstance = memoize(makeInstance);
 
-function makeInstance(wdkService: WdkService): ParamValueStore {
+function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueStore {
+  const _store = localforage.createInstance({
+    name: `ParamValueStore/${serviceUrl}`
+  });
+
   return {
-    clearParamValues: noop,
-    fetchParamValues: () => Promise.resolve({}),
-    updateParamValues: noop
+    clearParamValues: () => {
+      return _store.clear();
+    },
+    fetchParamValues: (...args) => {
+      const storeKey = makeStoreKey(...args);
+
+      return _store.getItem(storeKey);
+    },
+    updateParamValues: (newParamValues, ...keyArgs) => {
+      const storeKey = makeStoreKey(...keyArgs);
+
+      return _store.setItem(storeKey, newParamValues);
+    }
   };
+}
+
+function makeStoreKey(
+  prefix: string | undefined,
+  recordClassUrlSegment: string,
+  searchUrlSegment: string,
+  parameterName: string
+) {
+  return `${prefix ?? 'parameter'}/${recordClassUrlSegment}/${searchUrlSegment}/${parameterName}`;
 }

--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -42,5 +42,5 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
 }
 
 function makeParamStoreKey(paramContext: string) {
-  return `paramValues/${paramContext}`;
+  return `param-values/${paramContext}`;
 }

--- a/Client/src/Utils/StepAnalysisUtils.ts
+++ b/Client/src/Utils/StepAnalysisUtils.ts
@@ -13,7 +13,7 @@ import {
   record,
   string
 } from './Json';
-import { ParameterGroup, SearchConfig } from './WdkModel';
+import { ParameterGroup, ParameterValues } from './WdkModel';
 import { paramGroupDecoder } from '../Service/Mixins/SearchesService';
 import { ValidStepValidation, InvalidStepValidation } from 'wdk-client/Utils/WdkUser';
 
@@ -33,7 +33,7 @@ export interface StepAnalysisType {
   groups: ParameterGroup[]
 }
 
-export type FormParams = SearchConfig['parameters'];
+export type FormParams = ParameterValues;
 
 export type StepAnalysisStatus =
   | 'CREATED'

--- a/Client/src/Utils/WdkModel.ts
+++ b/Client/src/Utils/WdkModel.ts
@@ -334,7 +334,7 @@ export interface Answer {
 }
 
 export interface SearchConfig {
-  parameters: Record<string, string>;
+  parameters: ParameterValues;
   legacyFilterName?: string;
   filters?: FilterValueArray;
   columnFilters?: Record<string,Record<string,any>>

--- a/Client/src/Views/Question/DefaultQuestionForm.scss
+++ b/Client/src/Views/Question/DefaultQuestionForm.scss
@@ -29,12 +29,7 @@
 
   &ResetFormButton.btn {
     display: block;
-    width: 100%;
-    margin: 1em auto;
-
-    .fa {
-      margin: 0 0.25em;
-    }
+    margin: 1em 0 1em auto;
   }
 
   &ShowHideGroup {

--- a/Client/src/Views/Question/DefaultQuestionForm.scss
+++ b/Client/src/Views/Question/DefaultQuestionForm.scss
@@ -27,6 +27,16 @@
     padding-top: 1em;
   }
 
+  &ResetFormButton.btn {
+    display: block;
+    width: 100%;
+    margin: 1em auto;
+
+    .fa {
+      margin: 0 0.25em;
+    }
+  }
+
   &ShowHideGroup {
     border: 1px solid #eaeaea;
     background-color: #f0f0f0;

--- a/Client/src/Views/Question/DefaultQuestionForm.scss
+++ b/Client/src/Views/Question/DefaultQuestionForm.scss
@@ -28,8 +28,8 @@
   }
 
   &ResetFormButton.btn {
-    display: block;
-    margin: 1em 0 1em auto;
+    font-size: 1.1em;
+    margin: 1em 0;
   }
 
   &ShowHideGroup {

--- a/Client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/Client/src/Views/Question/DefaultQuestionForm.tsx
@@ -172,13 +172,11 @@ export default function DefaultQuestionForm(props: Props) {
       />
       <StepValidationInfo stepValidation={stepValidation} question={question} isRevise={submissionMetadata.type === 'edit-step'}/>
       {resetFormConfig.offered && <ResetFormButton {...resetFormConfig} />}
-      <hr />
       <form onSubmit={handleSubmit} noValidate={!validateForm}>
         {question.groups
           .filter(group => group.displayType !== 'hidden')
           .map(group => renderParamGroup(group, props))
         }
-        <hr />
         {resetFormConfig.offered && <ResetFormButton {...resetFormConfig} />}
         <hr />
         <SubmitSection
@@ -247,7 +245,7 @@ function ResetFormButton({
     <button
       type="button"
       disabled={disabled}
-      className={cx('ResetFormButton')}
+      className={`${cx('ResetFormButton')} btn`}
       onClick={onResetForm}
     >
       {resetFormContent}

--- a/Client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/Client/src/Views/Question/DefaultQuestionForm.tsx
@@ -226,7 +226,7 @@ export function QuestionHeader(props: QuestionHeaderProps) {
 
 export type ResetFormConfig =
   | { offered: false }
-  | { offered: true } & ResetFormButtonProps;
+  | { disabled: boolean, offered: true } & ResetFormButtonProps;
 
 interface ResetFormButtonProps {
   disabled?: boolean;

--- a/Client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/Client/src/Views/Question/DefaultQuestionForm.tsx
@@ -82,7 +82,8 @@ export default function DefaultQuestionForm(props: Props) {
     submitButtonText,
     recordClass,
     validateForm = true,
-    containerClassName
+    containerClassName,
+    resetFormConfig
   } = props;
   const {
     question,
@@ -170,11 +171,16 @@ export default function DefaultQuestionForm(props: Props) {
         headerText={`Identify ${recordClass.displayNamePlural} based on ${question.displayName}`}
       />
       <StepValidationInfo stepValidation={stepValidation} question={question} isRevise={submissionMetadata.type === 'edit-step'}/>
+      {resetFormConfig.offered && <ResetFormButton {...resetFormConfig} />}
+      <hr />
       <form onSubmit={handleSubmit} noValidate={!validateForm}>
         {question.groups
           .filter(group => group.displayType !== 'hidden')
           .map(group => renderParamGroup(group, props))
         }
+        <hr />
+        {resetFormConfig.offered && <ResetFormButton {...resetFormConfig} />}
+        <hr />
         <SubmitSection
           className={cx('SubmitSection')}
           tooltipPosition={tooltipPosition}
@@ -222,19 +228,25 @@ export function QuestionHeader(props: QuestionHeaderProps) {
     : <></>;
 }
 
-type ResetFormConfig =
+export type ResetFormConfig =
   | { offered: false }
   | { offered: true } & ResetFormButtonProps;
 
 interface ResetFormButtonProps {
+  disabled?: boolean;
   onResetForm: () => void;
   resetFormContent: React.ReactNode;
 }
 
-function ResetFormButton({ onResetForm, resetFormContent }: ResetFormButtonProps) {
+function ResetFormButton({
+  disabled,
+  onResetForm,
+  resetFormContent
+}: ResetFormButtonProps) {
   return (
     <button
       type="button"
+      disabled={disabled}
       className={cx('ResetFormButton')}
       onClick={onResetForm}
     >

--- a/Client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/Client/src/Views/Question/DefaultQuestionForm.tsx
@@ -7,12 +7,12 @@ import { Seq } from 'wdk-client/Utils/IterableUtils';
 import { Parameter, ParameterGroup, RecordClass } from 'wdk-client/Utils/WdkModel';
 import { QuestionState, QuestionWithMappedParameters } from 'wdk-client/StoreModules/QuestionStoreModule';
 import {
+  SubmissionMetadata,
   changeGroupVisibility,
-  updateParamValue,
   submitQuestion,
   updateCustomQuestionName,
-  updateQuestionWeight,
-  SubmissionMetadata
+  updateParamValue,
+  updateQuestionWeight
 } from 'wdk-client/Actions/QuestionActions';
 import 'wdk-client/Views/Question/DefaultQuestionForm.scss';
 import { TooltipPosition } from 'wdk-client/Components/Overlays/Tooltip';
@@ -39,6 +39,7 @@ export type Props = {
   DescriptionComponent?: (props: { description?: string, navigatingToDescription: boolean }) => JSX.Element;
   onClickDescriptionLink?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   onSubmit?: (e: React.FormEvent) => boolean | void;
+  resetFormConfig: ResetFormConfig;
   containerClassName?: string;
 }
 
@@ -73,9 +74,24 @@ export const useDefaultOnSubmit = (
   );
 
 export default function DefaultQuestionForm(props: Props) {
-
-  const { dispatchAction, onSubmit, submissionMetadata, state, submitButtonText, recordClass, validateForm = true, containerClassName } = props;
-  const { question, customName, paramValues, weight, stepValidation, submitting } = state;
+  const {
+    dispatchAction,
+    onSubmit,
+    submissionMetadata,
+    state,
+    submitButtonText,
+    recordClass,
+    validateForm = true,
+    containerClassName
+  } = props;
+  const {
+    question,
+    customName,
+    paramValues,
+    weight,
+    stepValidation,
+    submitting
+  } = state;
 
   let defaultOnSubmit = useDefaultOnSubmit(dispatchAction, question.urlSegment, submissionMetadata, false);
   let defaultOnWebservicesLinkClick = useDefaultOnSubmit(dispatchAction, question.urlSegment, submissionMetadata, true);
@@ -204,6 +220,27 @@ export function QuestionHeader(props: QuestionHeaderProps) {
       </div>
     )
     : <></>;
+}
+
+type ResetFormConfig =
+  | { offered: false }
+  | { offered: true } & ResetFormButtonProps;
+
+interface ResetFormButtonProps {
+  onResetForm: () => void;
+  resetFormContent: React.ReactNode;
+}
+
+function ResetFormButton({ onResetForm, resetFormContent }: ResetFormButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cx('ResetFormButton')}
+      onClick={onResetForm}
+    >
+      {resetFormContent}
+    </button>
+  );
 }
 
 export function renderDefaultParamGroup(group: ParameterGroup, formProps: Props) {

--- a/Client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/Client/src/Views/Question/DefaultQuestionForm.tsx
@@ -177,8 +177,6 @@ export default function DefaultQuestionForm(props: Props) {
           .filter(group => group.displayType !== 'hidden')
           .map(group => renderParamGroup(group, props))
         }
-        {resetFormConfig.offered && <ResetFormButton {...resetFormConfig} />}
-        <hr />
         <SubmitSection
           className={cx('SubmitSection')}
           tooltipPosition={tooltipPosition}

--- a/Client/src/Views/Question/Params/DatasetParam.tsx
+++ b/Client/src/Views/Question/Params/DatasetParam.tsx
@@ -79,7 +79,7 @@ function reduce(state: State = defaultState, action: Action): State {
       return {
         ...state,
         sourceType: 'idList',
-        idList: initialParamData
+        idList: initialParamData?.[initialListName] != null
           ? initialParamData[initialListName]
           : (parameter as DatasetParam).defaultIdList
       }

--- a/Client/src/Views/Strategy/CombineStepMenu.tsx
+++ b/Client/src/Views/Strategy/CombineStepMenu.tsx
@@ -317,10 +317,8 @@ export const CombineStepMenu = connect<StateProps, DispatchProps, OwnProps, Prop
         updateActiveQuestion({
           searchName: booleanSearchUrlSegment,
           autoRun: false,
-          stepId: undefined,
-          initialParamData: {
-            [BOOLEAN_OPERATOR_PARAM_NAME]: CombineOperator.Intersect
-          }
+          prepopulateWithLastParamValues: false,
+          stepId: undefined
         })
       )
     },

--- a/Client/src/Views/Strategy/CombineStepMenu.tsx
+++ b/Client/src/Views/Strategy/CombineStepMenu.tsx
@@ -11,11 +11,11 @@ import { QuestionState, DEFAULT_STRATEGY_NAME } from 'wdk-client/StoreModules/Qu
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { Parameter } from 'wdk-client/Utils/WdkModel';
 import { AddStepOperationMenuProps } from 'wdk-client/Views/Strategy/AddStepPanel';
-import { MenuChoicesContainer, MenuChoice, inputResultSetDescription } from 'wdk-client/Views/Strategy/AddStepUtils';
+import { MenuChoicesContainer, MenuChoice } from 'wdk-client/Views/Strategy/AddStepUtils';
 import { cxStepBoxes as cxOperator } from 'wdk-client/Views/Strategy/ClassNames';
 import { SearchInputSelector } from 'wdk-client/Views/Strategy/SearchInputSelector';
 import { AddType } from 'wdk-client/Views/Strategy/Types';
-import { combineOperatorOrder, BOOLEAN_OPERATOR_PARAM_NAME, CombineOperator } from 'wdk-client/Views/Strategy/StrategyUtils';
+import { BOOLEAN_OPERATOR_PARAM_NAME, CombineOperator, combineOperatorOrder } from 'wdk-client/Views/Strategy/StrategyUtils';
 
 import 'wdk-client/Views/Strategy/CombineStepMenu.scss';
 
@@ -317,7 +317,10 @@ export const CombineStepMenu = connect<StateProps, DispatchProps, OwnProps, Prop
         updateActiveQuestion({
           searchName: booleanSearchUrlSegment,
           autoRun: false,
-          stepId: undefined
+          stepId: undefined,
+          initialParamData: {
+            [BOOLEAN_OPERATOR_PARAM_NAME]: CombineOperator.Intersect
+          }
         })
       )
     },


### PR DESCRIPTION
Co-depends on https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/29

This PR... 

1. Introduces a new (IndexedDB-backed) `paramValueStore` WDK Client dependency, which can be used to persist a user's parameter value selections in a variety of contexts.

2. Uses this `paramValueStore` to persist the user's param value choices on search pages. (More precisely, the `QuestionController` now receives an optional `prepopulateWithLastParamValues` prop, which, if enabled, signals that the `paramValueStore` should prepopulate the form with the user's last param value selections for that question.)

**Note:**
The `paramValueStore` is cleared whenever (1) the user logs out or (2) the webapp is reloaded.