### PR TITLE
clearer verbiage, when using a link to a strategy, now that we provid…

### DIFF
--- a/Client/src/Views/Strategy/UnownedStrategy.tsx
+++ b/Client/src/Views/Strategy/UnownedStrategy.tsx
@@ -9,7 +9,13 @@ export default function UnownedStrategy() {
     <Banner banner={{
       type: 'danger',
       message: <div style={{ fontSize: '1.25em' }}>
-        The requested strategy does not exist, or it belongs to another user. In the latter case, ask them to use the share button (<IconAlt fa={StrategyActions.share.iconName}/>) to generate a valid URL that you may use to make a copy of their strategy. <Link to="/workspace/strategies">Dismiss</Link>
+        To access one of your strategies, please make sure you are logged in. <br />
+        If you are already logged in, then either the requested strategy does not exist, or it belongs to another user. <br />
+        <br />
+        If another user is sharing a strategy with you, ask them to use the share button (<IconAlt fa={StrategyActions.share.iconName}/>) in their panel, 
+          to generate a valid URL that you may use to make a copy of their strategy.  <br />
+         <br />
+        <Link to="/workspace/strategies">Dismiss</Link>
       </div>
     }}/>
   );


### PR DESCRIPTION
…e links on email warning them of outdated public strategies