### PR TITLE
Use ontology for Answer page

### DIFF
--- a/Client/src/Controllers/AnswerController.tsx
+++ b/Client/src/Controllers/AnswerController.tsx
@@ -77,8 +77,8 @@ type OwnProps = {
 }
 
 export type Props = {
-  stateProps: StateProps,
-  dispatchProps: DispatchProps
+  stateProps: StateProps;
+  dispatchProps: DispatchProps;
   ownProps: OwnProps;
 } & Options;
 
@@ -124,7 +124,7 @@ class AnswerController extends PageController<Props> {
     ) {
       let pagination = DEFAULT_PAGINATION;
       let sorting = DEFAULT_SORTING;
-      let displayInfo = { pagination, sorting, customName };
+      let displayInfo = { pagination, sorting, customName, attributes: [], tables: [] };
       let opts = { displayInfo, parameters, filterTerm, filterAttributes, filterTables };
       dispatchProps.loadAnswer(searchName, recordClassName, opts);
     }

--- a/Client/src/Service/Mixins/OntologiesService.ts
+++ b/Client/src/Service/Mixins/OntologiesService.ts
@@ -22,5 +22,10 @@ export default (base: ServiceBase) => {
       });
   }
 
-  return { getOntology };
+  async function getCategoriesOntology() {
+    const { categoriesOntologyName } = await base.getConfig();
+    return getOntology(categoriesOntologyName);
+  }
+
+  return { getOntology, getCategoriesOntology };
 }

--- a/Client/src/StoreModules/AnswerViewStoreModule.ts
+++ b/Client/src/StoreModules/AnswerViewStoreModule.ts
@@ -68,15 +68,15 @@ export function reduce(state: State = initialState, action: Action): State {
 function addAnswer( state: State, payload: EndLoadingWithAnswerPayload ) {
   let { answer, displayInfo, question, recordClass, parameters } = payload;
 
-  // in case we used a magic string to get attributes, reset fetched attributes in displayInfo
-  displayInfo.attributes = answer.meta.attributes;
-
   // need to filter wdk_weight from multiple places;
   let isNotWeight = (attr: string | AttributeField) =>
     typeof attr === 'string' ? attr != 'wdk_weight' : attr.name != 'wdk_weight';
 
   // collect attributes from recordClass and question
-  let allAttributes = recordClass.attributes.concat(question.dynamicAttributes).filter(isNotWeight);
+  let allAttributes = recordClass.attributes
+    .filter(attr => displayInfo.attributes.includes(attr.name))
+    .concat(question.dynamicAttributes)
+    .filter(isNotWeight);
 
   // use previously selected visible attributes unless they don't exist or the question changed
   let visibleAttributes = state.visibleAttributes;

--- a/Client/src/Utils/CategoryUtils.tsx
+++ b/Client/src/Utils/CategoryUtils.tsx
@@ -59,7 +59,7 @@ export const EMPTY_CATEGORY_TREE_NODE: CategoryTreeNode = {
   properties: {}
 };
 
-export function getId(node: CategoryTreeNode) {
+export function getId(node: CategoryTreeNode): string {
   return isIndividual(node)
     // FIXME Remove `fullName` hack when the urlSegment/name/fullName saga is resolved.
     ? node.wdkReference.name || (node.wdkReference as any).fullName

--- a/Client/src/Views/Answer/AnswerFilter.jsx
+++ b/Client/src/Views/Answer/AnswerFilter.jsx
@@ -86,7 +86,7 @@ class AnswerFilter extends React.Component {
 
   render() {
     let { filterAttributes, filterTables, showFilterFieldSelector } = this.state;
-    let { recordClass, filterTerm } = this.props;
+    let { recordClass, question, filterTerm, displayInfo } = this.props;
     let { displayNamePlural } = recordClass;
     let tooltipContent = (
       <div>
@@ -100,6 +100,10 @@ class AnswerFilter extends React.Component {
         </ul>
       </div>
     );
+    let attributes = recordClass.attributes.concat(question.dynamicAttributes)
+      .filter(attr => displayInfo.attributes.includes(attr.name));
+    let tables = recordClass.tables
+      .filter(table => displayInfo.tables.includes(table.name));
 
     return (
       <div className="wdk-Answer-filter">
@@ -120,7 +124,8 @@ class AnswerFilter extends React.Component {
         </Tooltip>*/}
 
         <AnswerFilterSelector
-          recordClass={recordClass}
+          attributes={attributes}
+          tables={tables}
           open={showFilterFieldSelector}
           onClose={this.toggleFilterFieldSelector}
           filterAttributes={filterAttributes}

--- a/Client/src/Views/Answer/AnswerFilterSelector.jsx
+++ b/Client/src/Views/Answer/AnswerFilterSelector.jsx
@@ -59,7 +59,8 @@ class AnswerFilterSelector extends Component {
     }
 
     let {
-      recordClass,
+      attributes,
+      tables,
       filterAttributes,
       filterTables,
       selectAll,
@@ -81,19 +82,15 @@ class AnswerFilterSelector extends Component {
           <a href="#" onClick={clearAll}>clear all</a>
         </p>
 
-        {recordClass.attributes
-          .filter(attr => attr.isDisplayable)
-          .map(attr => {
-            let isChecked = includes(filterAttributes, attr.name);
-            return renderFilterField(attr, isChecked, toggleAttribute);
-          })}
+        {attributes.map(attr => {
+          let isChecked = includes(filterAttributes, attr.name);
+          return renderFilterField(attr, isChecked, toggleAttribute);
+        })}
 
-        {recordClass.tables
-          .filter(table => table.isDisplayable)
-          .map(table => {
-            let isChecked = includes(filterTables, table.name);
-            return renderFilterField(table, isChecked, toggleTable);
-          })}
+        {tables.map(table => {
+          let isChecked = includes(filterTables, table.name);
+          return renderFilterField(table, isChecked, toggleTable);
+        })}
 
         <div className="wdk-Answer-filterFieldSelectorCloseIconWrapper">
           <button


### PR DESCRIPTION
This PR updates the Answer page to read the ontology to determine which attributes and tables to include for the results. It also addresses some performance issues in the Answer page, and adds a convenience function to access the categories ontology.