### PR TITLE
User Comment Attachments: don't offer a preview for non-image or unavailable attachments

### DIFF
--- a/Client/src/Controllers/UserCommentShowController.tsx
+++ b/Client/src/Controllers/UserCommentShowController.tsx
@@ -353,14 +353,7 @@ const mergeProps = (
                     id,
                     name,
                     description,
-                    preview: 
-                      (
-                        name.toLowerCase().includes('.png') || 
-                        name.toLowerCase().includes('.jpg') || 
-                        name.toLowerCase().includes('.jpeg')
-                      ) 
-                      ? `${webAppUrl}/service/user-comments/${comment.id}/attachments/${id}`
-                      : undefined
+                    url: `${webAppUrl}/service/user-comments/${comment.id}/attachments/${id}`
                   })
                 )
               } 

--- a/Client/src/Controllers/UserCommentShowController.tsx
+++ b/Client/src/Controllers/UserCommentShowController.tsx
@@ -345,15 +345,9 @@ const mergeProps = (
             <UserCommentUploadedFiles 
               uploadedFiles={
                 comment.attachments.map(
-                  ({
-                    id,
-                    name,
-                    description
-                  }) => ({
-                    id,
-                    name,
-                    description,
-                    url: `${webAppUrl}/service/user-comments/${comment.id}/attachments/${id}`
+                  (attachmentMetadata) => ({
+                    ...attachmentMetadata,
+                    url: `${webAppUrl}/service/user-comments/${comment.id}/attachments/${attachmentMetadata.id}`
                   })
                 )
               } 

--- a/Client/src/StoreModules/UserCommentFormStoreModule.ts
+++ b/Client/src/StoreModules/UserCommentFormStoreModule.ts
@@ -134,7 +134,8 @@ export function reduce(state: State = initialState, action: Action): State {
             return { 
                 ...state,
                 attachedFiles: action.payload.userComment.editMode 
-                    ? action.payload.userComment.formValues.attachments.map(({ id, name, description }) => ({ id, name, description }))
+                    // FIXME: Confirm that we don't need to make a shallow copy of each "attachment"
+                    ? action.payload.userComment.formValues.attachments.map(attachment => ({ ...attachment }))
                     : [], 
                 userCommentPostRequest: action.payload.userComment.editMode
                     ? getResponseToPostRequest(

--- a/Client/src/Utils/WdkUser.ts
+++ b/Client/src/Utils/WdkUser.ts
@@ -185,7 +185,8 @@ export interface KeyedUserCommentAttachedFileSpec extends UserCommentAttachedFil
 export interface UserCommentAttachedFile {
   id: number,
   description: string,
-  name: string
+  name: string,
+  mimeType: string
 }
 
 export type ReviewStatus =
@@ -242,7 +243,7 @@ export interface UserComment extends UserCommentPostRequest {
 
 export interface UserCommentGetResponse {
   additionalAuthors: string[];
-  attachments: { id: number, name: string, description: string, preview?: string }[];
+  attachments: UserCommentAttachedFile[];
   author: { userId: number, firstName: string, lastName: string, organization: string };
   categories: string[];
   commentDate: number;

--- a/Client/src/Views/UserCommentShow/UploadedFileRow.tsx
+++ b/Client/src/Views/UserCommentShow/UploadedFileRow.tsx
@@ -1,47 +1,27 @@
 import React from 'react';
 
-import { usePromise } from 'wdk-client/Hooks/PromiseHook';
+import { UserCommentAttachedFile } from 'wdk-client/Utils/WdkUser';
 
-export interface UserCommentUploadedFileEntry {
-  id: number;
-  name: string;
-  description: string;
-  url: string;
-}
-
-interface Props extends UserCommentUploadedFileEntry {
+interface Props extends UserCommentAttachedFile {
   entryClassName?: string;
+  url: string;
   rowNumber: number;
 }
 
 export const UploadedFileRow = ({
   name,
   description,
+  mimeType,
   url,
   entryClassName,
   rowNumber
 }: Props) => {
-  const { loading, value } = useContentType(url);
-
-  const isAvailable = (
-    !loading &&
-    value?.isAvailable
-  );
-  
-  const isImage = (
-    !loading &&
-    value?.isAvailable &&
-    value.contentType?.startsWith('image')
-  );
+  const isImage = mimeType.startsWith('image');
 
   return (
     <tr className={entryClassName}>
       <td>{rowNumber}</td>
-      <td>{
-        !isAvailable
-          ? name
-          : <a href={url}>{name}</a>
-      }</td>
+      <td><a href={url}>{name}</a></td>
       <td>{description}</td>
       <td>{
         !isImage
@@ -56,40 +36,4 @@ export const UploadedFileRow = ({
       }</td>
     </tr>
   );
-}
-
-type ContentType =
-  | { isAvailable: false }
-  | { isAvailable: true, contentType: string | null }
-
-function useContentType(url: string | undefined) {
-  return usePromise(async (): Promise<ContentType> => {
-    if (url == null) {
-      return {
-        isAvailable: false
-      };
-    }
-
-    try {
-      const response = await fetch(url, { method: 'HEAD' });
-      const isSuccess = (
-        response.status >= 200 && response.status < 300 ||
-        response.status === 304
-      );
-      const contentType = response.headers.get('Content-Type');
-
-      return isSuccess
-        ? {
-            isAvailable: true,
-            contentType
-          }
-        : {
-            isAvailable: false
-          };
-    } catch {
-      return {
-        isAvailable: false
-      };
-    }
-  }, [ url ]);
 }

--- a/Client/src/Views/UserCommentShow/UploadedFileRow.tsx
+++ b/Client/src/Views/UserCommentShow/UploadedFileRow.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { usePromise } from 'wdk-client/Hooks/PromiseHook';
+
+export interface UserCommentUploadedFileEntry {
+  id: number;
+  name: string;
+  description: string;
+  url: string;
+}
+
+interface Props extends UserCommentUploadedFileEntry {
+  entryClassName?: string;
+  rowNumber: number;
+}
+
+export const UploadedFileRow = ({
+  name,
+  description,
+  url,
+  entryClassName,
+  rowNumber
+}: Props) => {
+  const { loading, value } = useContentType(url);
+
+  const isAvailable = (
+    !loading &&
+    value?.isAvailable
+  );
+  
+  const isImage = (
+    !loading &&
+    value?.isAvailable &&
+    value.contentType?.startsWith('image')
+  );
+
+  return (
+    <tr className={entryClassName}>
+      <td>{rowNumber}</td>
+      <td>{
+        !isAvailable
+          ? name
+          : <a href={url}>{name}</a>
+      }</td>
+      <td>{description}</td>
+      <td>{
+        !isImage
+          ? null
+          : <a href={url}>
+              <img 
+                src={url}
+                width={80}
+                height={80} 
+              />
+            </a> 
+      }</td>
+    </tr>
+  );
+}
+
+type ContentType =
+  | { isAvailable: false }
+  | { isAvailable: true, contentType: string | null }
+
+function useContentType(url: string | undefined) {
+  return usePromise(async (): Promise<ContentType> => {
+    if (url == null) {
+      return {
+        isAvailable: false
+      };
+    }
+
+    try {
+      const response = await fetch(url, { method: 'HEAD' });
+      const isSuccess = (
+        response.status >= 200 && response.status < 300 ||
+        response.status === 304
+      );
+      const contentType = response.headers.get('Content-Type');
+
+      return isSuccess
+        ? {
+            isAvailable: true,
+            contentType
+          }
+        : {
+            isAvailable: false
+          };
+    } catch {
+      return {
+        isAvailable: false
+      };
+    }
+  }, [ url ]);
+}

--- a/Client/src/Views/UserCommentShow/UserCommentUploadedFiles.tsx
+++ b/Client/src/Views/UserCommentShow/UserCommentUploadedFiles.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
-import {
-  UploadedFileRow,
-  UserCommentUploadedFileEntry
-} from 'wdk-client/Views/UserCommentShow/UploadedFileRow';
+import { UserCommentAttachedFile } from 'wdk-client/Utils/WdkUser';
+import { UploadedFileRow } from 'wdk-client/Views/UserCommentShow/UploadedFileRow';
+
+interface UploadedFileEntry extends UserCommentAttachedFile {
+  url: string;
+}
 
 interface UserCommentUploadedFilesProps {
-  uploadedFiles: UserCommentUploadedFileEntry[];
+  uploadedFiles: UploadedFileEntry[];
   headerClassName?: string;
   entryClassName?: string;
 }

--- a/Client/src/Views/UserCommentShow/UserCommentUploadedFiles.tsx
+++ b/Client/src/Views/UserCommentShow/UserCommentUploadedFiles.tsx
@@ -1,23 +1,21 @@
 import React from 'react';
 
-interface UserCommentUploadedFileEntry {
-  id: number;
-  name: string;
-  description: string;
-  preview?: string;
-}
+import {
+  UploadedFileRow,
+  UserCommentUploadedFileEntry
+} from 'wdk-client/Views/UserCommentShow/UploadedFileRow';
 
-interface UserCommentUploadedFileProps {
+interface UserCommentUploadedFilesProps {
   uploadedFiles: UserCommentUploadedFileEntry[];
   headerClassName?: string;
   entryClassName?: string;
 }
 
-export const UserCommentUploadedFiles: React.SFC<UserCommentUploadedFileProps> = ({
+export const UserCommentUploadedFiles = ({
   uploadedFiles,
   headerClassName,
   entryClassName
-}) => (
+}: UserCommentUploadedFilesProps) => (
   uploadedFiles.length > 0 
     ? (
       <table className="wdk-UserCommentUploadedFiles">
@@ -30,29 +28,13 @@ export const UserCommentUploadedFiles: React.SFC<UserCommentUploadedFileProps> =
           </tr>
           {
             uploadedFiles.map(
-              ({ id, name, description, preview }, index) => (
-                <tr key={id} className={entryClassName}>
-                  <td>{index + 1}</td>
-                  <td>{
-                    preview
-                      ? <a href={preview}>{name}</a>
-                      : name
-                  }</td>
-                  <td>{description}</td>
-                  <td>{
-                    preview 
-                      ? <a 
-                          href={preview}
-                        >
-                          <img 
-                            src={preview}
-                            width={80}
-                            height={80} 
-                          />
-                        </a> 
-                      : null
-                  }</td>
-                </tr>
+              (uploadedFile, index) => (
+                <UploadedFileRow
+                  key={uploadedFile.id}
+                  entryClassName={entryClassName}
+                  rowNumber={index + 1}
+                  {...uploadedFile}
+                />
               )
             )
           }


### PR DESCRIPTION
This PR introduces more robust rendering of User Comment attachment metadata. More specifically, we now offer a preview of a User Comment attachment iff its MIME type is of the form "image/*". (Before, we were only offering this preview if the file's extension was one of three hardcoded types, which was a source of bugs.)

Depends on https://github.com/VEuPathDB/ApiCommonWebsite/pull/19