### PR TITLE
Append timestamp to image url to break browser cache

### DIFF
--- a/Client/src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisGoEnrichmentResults.tsx
+++ b/Client/src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisGoEnrichmentResults.tsx
@@ -164,7 +164,7 @@ export const StepAnalysisGoEnrichmentResults: React.FunctionComponent<StepAnalys
       />
       <WordCloudModal
         imgUrl={
-          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}`
+          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}&_=${Date.now()}`
         }
         open={wordCloudOpen}
         onClose={() => {

--- a/Client/src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
+++ b/Client/src/Core/MoveAfterRefactor/Components/StepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
@@ -156,7 +156,7 @@ export const StepAnalysisPathwayEnrichmentResults: React.SFC<StepAnalysisResultP
       />
       <WordCloudModal
         imgUrl={
-          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}`
+          `${webAppUrl}/service/users/current/steps/${analysisConfig.stepId}/analyses/${analysisConfig.analysisId}/resources?path=${analysisResult.imageDownloadPath}&_=${Date.now()}`
         }
         open={wordCloudOpen}
         onClose={() => {


### PR DESCRIPTION
This PR addresses https://redmine.apidb.org/issues/42389 by appending a timestamp to the word cloud image url used in the dialog component.