### PR TITLE
Add overrides for hook and `set` function.

### DIFF
--- a/Client/src/Hooks/StateWithHistory.ts
+++ b/Client/src/Hooks/StateWithHistory.ts
@@ -7,11 +7,17 @@ export interface Options {
 type NextState<T> = T | ((nextState: T) => T);
 
 interface Return<T, S = T> {
+  /** Current state of history */
   state: T | S,
+  /** Can history be undone? */
   canUndo: boolean;
+  /** Can history be redone? */
   canRedo: boolean;
+  /** Go to previous state, if available. */
   undo: () => void;
+  /** Go to next state, if available. */
   redo: () => void;
+  /** Add a new entry to history, replacing undo stack. */
   set: (nextState: NextState<T>) => void;
 }
 

--- a/Client/src/Hooks/StateWithHistory.ts
+++ b/Client/src/Hooks/StateWithHistory.ts
@@ -6,8 +6,8 @@ export interface Options {
 
 type NextState<T> = T | ((nextState: T) => T);
 
-interface Return<T> {
-  state: T,
+interface Return<T, S = T> {
+  state: T | S,
   canUndo: boolean;
   canRedo: boolean;
   undo: () => void;
@@ -19,7 +19,7 @@ interface Return<T> {
  * Use state hook with a history of the size provided via `options`. The initial returned state will be `undefined`.
  * @param options 
  */
-export function useStateWithHistory<T = undefined>(options: Options): Return<T | undefined>;
+export function useStateWithHistory<T = undefined>(options: Options): Return<T, undefined>;
 /**
  * Use state hook with a history of the size provided via `options`.
  * @param options 

--- a/Client/src/Hooks/StateWithHistory.ts
+++ b/Client/src/Hooks/StateWithHistory.ts
@@ -4,39 +4,67 @@ export interface Options {
   size: number;
 }
 
-export function useStateWithHistory<T>(initialState: T, options: Options) {
-  // history is a stack, so newest state is at head
-  const [historyState, setState] = useState({
+type NextState<T> = T | ((nextState: T) => T);
+
+interface Return<T> {
+  state: T,
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+  set: (nextState: NextState<T>) => void;
+}
+
+/**
+ * Use state hook with a history of the size provided via `options`. The initial returned state will be `undefined`.
+ * @param options 
+ */
+export function useStateWithHistory<T = undefined>(options: Options): Return<T | undefined>;
+/**
+ * Use state hook with a history of the size provided via `options`.
+ * @param options 
+ */
+export function useStateWithHistory<T>(initialState: T, options: Options): Return<T>;
+export function useStateWithHistory<T>(initialStateOrOptions: T | Options, optionsOrUndef?: Options) {
+  // If `optionsOrUndef` is undefined, then the first function signature is in
+  // use, otherwise the second is in use.
+  const options: Options = optionsOrUndef == null ? initialStateOrOptions as Options : optionsOrUndef;
+  const initialState: T | undefined = optionsOrUndef == null ? undefined: initialStateOrOptions as T;
+  // historyState.stack is a stack, so newest state is at head
+  // historyState.cursor is the current position of the stack
+  const [historyState, setHistoryState] = useState({
     cursor: 0,
-    history: [initialState]
+    stack: initialState == null ? [] : [initialState]
   });
-  // cursor is the current position of the stack
-  const canUndo = historyState.cursor < historyState.history.length - 1;
+  const canUndo = historyState.cursor < historyState.stack.length - 1;
   const canRedo = historyState.cursor > 0;
 
-  const set = useCallback((value: T) => {
-    setState(s => ({
+  const set = useCallback((nextState: NextState<T>) => {
+    setHistoryState(s => ({
       cursor: 0,
-      history: [value, ...s.history.slice(s.cursor, options.size - 1)]
+      stack: [
+        nextState instanceof Function ? nextState(s.stack[s.cursor]) : nextState,
+        ...s.stack.slice(s.cursor, options.size - 1)
+      ]
     }))
   }, [options.size]);
 
   const undo = useCallback(() => {
-    setState(s => s.cursor === s.history.length - 1 ? s : {
+    setHistoryState(s => s.cursor === s.stack.length - 1 ? s : {
       ...s,
       cursor: s.cursor + 1
     })
   }, []);
 
   const redo = useCallback(() => {
-    setState(s => s.cursor === 0 ? s : {
+    setHistoryState(s => s.cursor === 0 ? s : {
       ...s,
       cursor: s.cursor - 1
     })
   }, []);
 
   return {
-    state: historyState.history[historyState.cursor],
+    state: historyState.stack[historyState.cursor],
     canUndo,
     canRedo,
     set,

--- a/Client/src/Hooks/__tests__/StateWithHistoryTest.ts
+++ b/Client/src/Hooks/__tests__/StateWithHistoryTest.ts
@@ -45,4 +45,26 @@ describe('useStateWithHistory', () => {
     expect(result.current.canUndo).toBeTruthy();
     expect(result.current.canRedo).toBeTruthy();
   });
+
+  it('should allow functional state updates', () => {
+    const { result } = renderHook(() => useStateWithHistory(1, { size: 2 }));
+    act(() => {
+      result.current.set(n => n * 3);
+    });
+    expect(result.current.state).toBe(3);
+    act(() => {
+      result.current.set(n => n * 3);
+    });
+    expect(result.current.state).toBe(9);
+  });
+
+  it('should allow to initialize with undefined', () => {
+    const { result } = renderHook(() => useStateWithHistory<number>({ size: 2 }));
+    expect(result.current.state).toBeUndefined();
+    act(() => {
+      result.current.set(1);
+      result.current.set(2);
+    });
+    expect(result.current.state).toBe(2);
+  })
 })


### PR DESCRIPTION
The hook override allows no initial state to be provided, in which case the type is `T | undefined`.

The set function override allows for functional state updates.