### PR TITLE
Remove padding, margin, border from input and use outline

### DIFF
--- a/Client/src/Components/InputControls/wdk-SaveableTextEditor.scss
+++ b/Client/src/Components/InputControls/wdk-SaveableTextEditor.scss
@@ -21,7 +21,11 @@
     flex-flow: column nowrap;
 
     input, textarea {
-      margin: 2px;
+      margin: 0 !important;
+      padding: 0 !important;
+      border: none !important;
+      outline-offset: 2px;
+      outline: solid 1px black;
     }
   }
 

--- a/Client/src/Views/Strategy/StepBoxes.css
+++ b/Client/src/Views/Strategy/StepBoxes.css
@@ -480,11 +480,14 @@ button.StepBoxes--EditButton:hover {
 .StepBoxes--StepDetailsHeading {
   font-size: 1.2em;
   font-weight: bold;
+  display: flex;
+  align-items: center;
 }
 
 .StepBoxes--StepDetailsName {
   font-style: italic;
   font-weight: normal;
+  margin-left: 1ex;
 }
 
 .StepBoxes--StepDetailsName fieldset {


### PR DESCRIPTION
Update styles to prevent content shifting when `SaveableTextEditor` is in edit mode.