### PR TITLE
Use optional chaining to work around a potential null first()

### DIFF
--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -162,7 +162,7 @@ const observeInit: Observer = (action$, state$, services) => action$.pipe(
 
         const filters = getFilters(paramValues[paramName]);
         const activeField = filters.length === 0
-          ? getFilterFields(getFilterParamNewFromState(getQuestionState(state$.value, searchName), paramName)).first().term
+          ? getFilterFields(getFilterParamNewFromState(getQuestionState(state$.value, searchName), paramName)).first()?.term
           : filters[0].field;
 
         // The order here is important. We want to first merge the child
@@ -200,7 +200,7 @@ const observeUpdateDependentParamsActiveField: Observer = (action$, state$, { wd
 
         const activeField = ontology.findIndex(item => item.term === activeOntologyTerm) > -1
           ? activeOntologyTerm
-          : filters.length === 0 ? getFilterFields(parameter).first().term : filters[0].field;
+          : filters.length === 0 ? getFilterFields(parameter).first()?.term : filters[0].field;
 
         return merge(
           of(invalidateOntologyTerms({


### PR DESCRIPTION
Spotted happening when a question has an empty ontology, which can be triggered by an action `question/update-params` with an empty `ontology` param, I got it with this action:

```
{
  type: 'question/update-params',
  payload: {
    searchName: 'MicrobiomeSampleByMetadata',
    parameters: [
      {
        displayName: 'Samples',
        hideEmptyOntologyNodes: true,
        values: {},
        sortLeavesBeforeBranches: true,
        minSelectedCount: -1,
        isVisible: true,
        type: 'filter',
        countPredictsAnswerCount: true,
        help: 'Select reference samples.',
        dependentParams: [],
        isReadOnly: false,
        allowEmptyValue: false,
        name: 'samples_filter_metadata_wiz',
        initialDisplayValue: '{"filters":[]}',
        ontology: [],
        group: 'samples_metadata'
      }
    ]
  }
}
```

The empty ontology happens during mad clicking around, and makes the UI break. With this change, the empty ontology does not break stuff, and goes away with more clicking, so it's probably not too bad in itself.