### PR TITLE
Update defaults for histogram, and allow configuration.

### DIFF
--- a/Client/src/Components/AttributeFilter/Histogram.jsx
+++ b/Client/src/Components/AttributeFilter/Histogram.jsx
@@ -122,7 +122,6 @@ var Histogram = (function() {
     }
 
     getStateFromProps(props) {
-      // Set default yAxis max based on distribution
       var { xaxisMin, xaxisMax } = this.getXAxisMinMax(props);
       var binStart = props.uiState.binStart ?? props.chartType === 'date' ? xaxisMin / DAY : xaxisMin;
       var binSize = props.uiState.binSize ?? this.getDefaultBinSize(props);
@@ -142,11 +141,12 @@ var Histogram = (function() {
     getDefaultBinSize(props) {
       if (props.chartType === 'date') return 1;
       const { min, max } = this.getRange(props.distribution);
-      // Assume probablity or percentage
       if (this.isProbablity(props)) return max / 100;
       const numVals = props.distribution.reduce((sum, entry) => sum + entry.count, 0);
       const padding = (max - min) / 100;
-      const binSize = (padding + max - min) / (Math.ceil(Math.log2(numVals)) + 1);
+      // Compute number of bins using Sturge's rule
+      const numBins = Math.ceil(Math.log2(numVals)) + 1;
+      const binSize = (padding + max - min) / numBins;
       return binSize || (max - Math.min(0, min)) / 10;
     }
 

--- a/Client/src/Components/AttributeFilter/HistogramField.jsx
+++ b/Client/src/Components/AttributeFilter/HistogramField.jsx
@@ -253,6 +253,8 @@ export default class HistogramField extends React.Component {
           yaxisLabel={displayName}
           uiState={activeFieldState}
           onUiStateChange={this.handleRangeScaleChange}
+          truncateYAxis={this.props.histogramTruncateYAxisDefault}
+          defaultScaleYAxis={this.props.histogramScaleYAxisDefault}
         />
 
         <FilterLegend {...this.props} />

--- a/Client/src/Components/AttributeFilter/ServerSideAttributeFilter.jsx
+++ b/Client/src/Components/AttributeFilter/ServerSideAttributeFilter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { wrappable } from 'wdk-client/Utils/ComponentUtils';
 
 import FieldList from 'wdk-client/Components/AttributeFilter/FieldList';
 import FilterList from 'wdk-client/Components/AttributeFilter/FilterList';
@@ -8,7 +9,7 @@ import FieldFilter from 'wdk-client/Components/AttributeFilter/FieldFilter';
 /**
  * Filtering UI for server-side filtering.
  */
-export default function ServerSideAttributeFilter (props) {
+function ServerSideAttributeFilter (props) {
   var { displayName, fieldTree, hideFilterPanel, hideFieldPanel } = props;
 
   if (fieldTree == null) {
@@ -54,6 +55,8 @@ ServerSideAttributeFilter.propTypes = {
   hideGlobalCounts: PropTypes.bool,
   selectByDefault: PropTypes.bool, // affects UI state for when no filter is applied
   minSelectedCount: PropTypes.number,
+  histogramScaleYAxisDefault: PropTypes.bool,
+  histogramTruncateYAxisDefault: PropTypes.bool,
 
   // state
   fieldTree: fieldTreePropType,
@@ -84,5 +87,15 @@ ServerSideAttributeFilter.defaultProps = {
   hideFilterPanel: false,
   hideFieldPanel: false,
   hideGlobalCounts: false,
-  selectByDefault: false
+  selectByDefault: false,
+  histogramScaleYAxisDefault: true,
+  histogramTruncateYAxisDefault: false,
 };
+
+export default wrappable(ServerSideAttributeFilter);
+
+export function withOptions(options) {
+  return function ServerSideAttributeFilterWithOptions(props) {
+    return <ServerSideAttributeFilter {...options} {...props}/>
+  }
+}


### PR DESCRIPTION
This PR changes the default settings for the histogram view in FilterParam.

* Compute and apply default bin size
* Always include 0 in default xaxis range
* Use log scale for yaxis
* Do not truncate yaxis

The yaxis defaults can be configured using a component override.

refs https://redmine.apidb.org/issues/43098