### PR TITLE
Result Panel: two related issues around loading step analyses

### DIFF
--- a/Client/src/Controllers/ResultPanelController.tsx
+++ b/Client/src/Controllers/ResultPanelController.tsx
@@ -307,7 +307,10 @@ const mergeProps = (
 
 function resultTypeHasChanged(prevResultType: ResultType, nextResultType: ResultType) {
   return prevResultType.type === 'step' && nextResultType.type === 'step'
-    ? prevResultType.step.id !== nextResultType.step.id
+    ? (
+      prevResultType.step.searchName !== nextResultType.step.searchName ||
+      !isEqual(prevResultType.step.searchConfig, nextResultType.step.searchConfig)
+    )
     : !isEqual(prevResultType, nextResultType);
 }
 

--- a/Client/src/Controllers/ResultPanelController.tsx
+++ b/Client/src/Controllers/ResultPanelController.tsx
@@ -104,7 +104,10 @@ interface ResultPanelControllerProps {
 class ResultPanelController extends ViewController< ResultPanelControllerProps > {
 
   loadData(prevProps?: ResultPanelControllerProps) {
-    if (prevProps == null || !isEqual(prevProps.resultType, this.props.resultType)) {
+    if (
+      prevProps == null ||
+      resultTypeHasChanged(prevProps.resultType, this.props.resultType)
+    ) {
       this.props.loadTabs(this.props.resultType);
     }
   }
@@ -301,6 +304,12 @@ const mergeProps = (
     ))
   ]
 });
+
+function resultTypeHasChanged(prevResultType: ResultType, nextResultType: ResultType) {
+  return prevResultType.type === 'step' && nextResultType.type === 'step'
+    ? prevResultType.step.id !== nextResultType.step.id
+    : !isEqual(prevResultType, nextResultType);
+}
 
 export default connect(
   mapStateToProps,

--- a/Client/src/Core/MoveAfterRefactor/StoreModules/StepAnalysis/StepAnalysisObservers.ts
+++ b/Client/src/Core/MoveAfterRefactor/StoreModules/StepAnalysis/StepAnalysisObservers.ts
@@ -41,7 +41,7 @@ import {
 import { ActionsObservable, StateObservable } from 'redux-observable';
 import { Action } from 'redux';
 import { EpicDependencies } from '../../../Store';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { map, filter, mergeMap, withLatestFrom, delay, mergeAll } from 'rxjs/operators';
 import {
   finishLoadingTabListing,
@@ -78,9 +78,9 @@ export const observeStartLoadingTabListing = (action$: ActionsObservable<Action>
           ...analysis
         }));
 
-        return [
-          finishLoadingTabListing(tabListing, choices)
-        ];
+        return state$.value.stepId === stepId
+          ? of(finishLoadingTabListing(tabListing, choices))
+          : EMPTY;
       }
       catch (ex) {
         return EMPTY;


### PR DESCRIPTION
This PR addresses [this Trello](https://trello.com/c/eu1oPJna/1454-bug-in-step-results-analysis-tab-in-child-step-stays-on-new-boolean) as follows:

1. Step Analysis Redux: after loading a step's analyses, don't update the tab listing if the user has navigated away from the step.

2. Result Panel Controller: if both the previous and current `resultType` are `step`s, don't reload the tabs unless the step id has changed. (Currently, adding a step causes the previous step's tab listing to be reloaded before the client redirects to the new step. This is occurring because the `step`s in the previous and current `resultTypes` are nearly identical, except for their `lastRunTime`s.)

**Note 1:** Only (1) is actually necessary to fix the bug. (2) addresses an unnecessary service call which revealed the bug.

**Note 2:** It was considered, but ruled out, to update the Step Analysis Redux to use `IndexedState` (with step id serving as the index).