### PR TITLE
Append request url to fetch errors

### DIFF
--- a/Client/src/Service/Mixins/TemporaryFilesService.ts
+++ b/Client/src/Service/Mixins/TemporaryFilesService.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { ServiceBase } from 'wdk-client/Service/ServiceBase';
 import { ServiceError } from 'wdk-client/Service/ServiceError';
+import { appendUrlAndRethrow } from '../ServiceUtils';
 
 export default (base: ServiceBase) => {
 
@@ -27,7 +28,7 @@ export default (base: ServiceBase) => {
           uuid()
         );
       })
-    })
+    }).catch(appendUrlAndRethrow(base.serviceUrl + path))
   }
 
   return {

--- a/Client/src/Service/Mixins/UserUploadService.ts
+++ b/Client/src/Service/Mixins/UserUploadService.ts
@@ -1,6 +1,7 @@
 import { ServiceBase } from 'wdk-client/Service/ServiceBase';
 import { UserDatasetUpload, NewUserDataset } from 'wdk-client/Utils/WdkModel';
 import * as Decode from 'wdk-client/Utils/Json';
+import { appendUrlAndRethrow } from '../ServiceUtils';
 
 const serviceUrl = '/dataset-import';
 
@@ -21,7 +22,7 @@ function fetchWithCredentials(path: string, method: string, body: any, contentTy
       credentials: 'include',
       headers: new Headers(Object.assign({}, authO, contentTypeO))
     }
-  );
+  ).catch(appendUrlAndRethrow(serviceUrl + path));
 }
 
 /*

--- a/Client/src/Service/ServiceBase.ts
+++ b/Client/src/Service/ServiceBase.ts
@@ -10,6 +10,7 @@ import { ServiceError } from 'wdk-client/Service/ServiceError';
 import { Question } from 'wdk-client/Utils/WdkModel';
 import { keyBy } from 'lodash';
 import { expandedRecordClassDecoder } from 'wdk-client/Service/Decoders/RecordClassDecoders';
+import { appendUrlAndRethrow } from './ServiceUtils';
 
 
 /**
@@ -220,7 +221,7 @@ export const ServiceBase = (serviceUrl: string) => {
           response.headers.get('x-log-marker') || uuid()
         );
       });
-    }) as Promise<T>
+    }).catch(appendUrlAndRethrow(serviceUrl + url)) as Promise<T>
   }
 
   /**

--- a/Client/src/Service/ServiceUtils.ts
+++ b/Client/src/Service/ServiceUtils.ts
@@ -1,0 +1,7 @@
+export const appendUrlAndRethrow = (url: string) => (error: unknown) => {
+  if (error instanceof Error) {
+    const { message } = error;
+    error.message = `${message}: [attempting to request ${url}]`;
+  }
+  throw error;
+}


### PR DESCRIPTION
This PR appends the request url to errors thrown by `fetch` attempts. There are likely other places where we use `fetch`, but this is first pass to improve error reporting.