### PR TITLE
Path to biom, pre-fill form from URL

### DIFF
--- a/Client/src/Controllers/UserDatasetAllUploadsController.tsx
+++ b/Client/src/Controllers/UserDatasetAllUploadsController.tsx
@@ -41,19 +41,7 @@ class UserDatasetAllUploadsController extends PageController<Props> {
     return "Recent Uploads";
   }
 
-  renderGuestView(){
-    return (
-      <UserDatasetEmptyState message={
-        <button
-          type="button"
-          className="btn"
-          onClick={() => this.props.actions.showLoginForm()}
-        >Please log in to view your data set uploads.</button>
-      }/>
-    );
-  }
-
-  renderAllUploads(){
+  renderView(){
     return (
       <div className="stack">
         <AllUploads 
@@ -62,12 +50,6 @@ class UserDatasetAllUploadsController extends PageController<Props> {
           actions={this.props.actions} />
       </div>
     );
-  }
-
-  renderView() {
-    return this.props.user && this.props.user.isGuest
-      ? this.renderGuestView()
-      : this.renderAllUploads();
   }
 }
 

--- a/Client/src/Controllers/UserDatasetListController.tsx
+++ b/Client/src/Controllers/UserDatasetListController.tsx
@@ -95,30 +95,10 @@ class UserDatasetListController extends PageController <Props> {
     return this.props.stateProps.userDatasetList.status === 'error';
   }
 
-  renderGuestView() {
-    const title = this.getTitle();
-    return (
-      <div className="UserDatasetList-Controller">
-        <h1 className="UserDatasetList-Title">{title}</h1>
-        <div className="UserDatasetList-Content">
-          <UserDatasetEmptyState message={
-            <button
-              type="button"
-              className="btn"
-              onClick={() => this.props.dispatchProps.showLoginForm()}
-            >Please log in to access My Data Sets.</button>
-          } />
-        </div>
-      </div>
-    )
-  }
-
   renderView () {
     const { config, user } = this.props.stateProps.globalData;
 
     if (user == null || config == null) return this.renderDataLoading();
-
-    if (user.isGuest) return this.renderGuestView();
 
     if (this.props.stateProps.userDatasetList.status !== 'complete') return null;
 

--- a/Client/src/Controllers/UserDatasetNewUploadController.tsx
+++ b/Client/src/Controllers/UserDatasetNewUploadController.tsx
@@ -56,7 +56,7 @@ class UserDatasetUploadController extends PageController<MergedProps> {
     return (
       <div className="stack">
         { projectName === 'MicrobiomeDB'
-          ? <MicrobiomeDBUploadForm badUploadMessage={this.props.badUploadMessage} submitForm={this.props.userEvents.submitUploadForm} />
+          ? <MicrobiomeDBUploadForm badUploadMessage={this.props.badUploadMessage} submitForm={this.props.userEvents.submitUploadForm} urlParams={this.props.urlParams}/>
           : this.renderMissingForm()
         }
       </div>

--- a/Client/src/Controllers/UserDatasetNewUploadController.tsx
+++ b/Client/src/Controllers/UserDatasetNewUploadController.tsx
@@ -39,18 +39,6 @@ class UserDatasetUploadController extends PageController<MergedProps> {
     return "Upload My New Data Set";
   }
 
-  renderGuestView(){
-    return (
-      <UserDatasetEmptyState message={
-        <button
-          type="button"
-          className="btn"
-          onClick={() => this.props.userEvents.showLoginForm()}
-        >Please log in to upload a new data set.</button>
-      }/>
-    );
-  }
-
   renderMissingForm(){
     const projectName = this.props.config != null ? this.props.config.displayName : undefined;
     return (
@@ -62,7 +50,7 @@ class UserDatasetUploadController extends PageController<MergedProps> {
     );
   }
 
-  renderUploadForm(){
+  renderView(){
     const projectName = this.props.config != null ? this.props.config.displayName : undefined;
 
     return (
@@ -72,14 +60,6 @@ class UserDatasetUploadController extends PageController<MergedProps> {
           : this.renderMissingForm()
         }
       </div>
-    );
-  }
-
-  renderView() {
-    return (
-      this.props.user && this.props.user.isGuest
-      ? this.renderGuestView()
-      : this.renderUploadForm()
     );
   }
 }

--- a/Client/src/Controllers/UserDatasetNewUploadController.tsx
+++ b/Client/src/Controllers/UserDatasetNewUploadController.tsx
@@ -18,7 +18,12 @@ type StateProps =
   & Pick<RootState['globalData'], 'user'>
   & Pick<RootState['globalData'], 'config'>;
 type DispatchProps = typeof actionCreators;
-type MergedProps = StateProps & { userEvents: DispatchProps };
+
+type OwnProps = {
+  urlParams: Record<string, string>;
+}
+
+type MergedProps = StateProps & { userEvents: DispatchProps } & OwnProps;
 
 class UserDatasetUploadController extends PageController<MergedProps> {
 
@@ -79,14 +84,14 @@ class UserDatasetUploadController extends PageController<MergedProps> {
   }
 }
 
-const enhance = connect<StateProps, DispatchProps, {}, MergedProps, RootState>(
+const enhance = connect<StateProps, DispatchProps, OwnProps, MergedProps, RootState>(
   (state: RootState) => ({
     badUploadMessage: state.userDatasetUpload.badUploadMessage,
     user: state.globalData.user,
     config: state.globalData.config
   }),
   actionCreators,
-  (stateProps, dispatchProps) => ({ ...stateProps, userEvents: dispatchProps })
+  (stateProps, dispatchProps, ownProps) => ({ ...stateProps, ...ownProps, userEvents: dispatchProps })
 )
 
 export default enhance(wrappable(UserDatasetUploadController));

--- a/Client/src/Core/WdkRoute.tsx
+++ b/Client/src/Core/WdkRoute.tsx
@@ -5,15 +5,16 @@ import { ErrorBoundary } from 'wdk-client/Controllers';
 
 interface Props extends RouteProps {
   requiresLogin: boolean;
+  disclaimerProps?: { toDoWhatMessage?: string, extraParagraphContent?: JSX.Element}
 }
 
 export default function WdkRoute(routeProps: Props) {
-  const { component: Component, requiresLogin, ...restProps } = routeProps;
+  const { component: Component, requiresLogin, disclaimerProps, ...restProps } = routeProps;
 
   const render = useCallback((props: RouteComponentProps<any, StaticContext, any>) => {
     const content = Component == null ? null
       : requiresLogin ? (
-        <LoginRequiredDisclaimer>
+        <LoginRequiredDisclaimer {...disclaimerProps || {}}>
           <Component {...props}/>
         </LoginRequiredDisclaimer>
       )

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -209,8 +209,8 @@ const routes: RouteEntry[] = [
   {
     path: '/workspace/datasets',
     exact: false,
-    requiresLogin: true,
-    component: (props: RouteComponentProps<{}>) => < UserDatasetsWorkspace rootPath={props.match.path}/>
+    requiresLogin: false, // uses custom guest views
+    component: (props: RouteComponentProps<{}>) => < UserDatasetsWorkspace rootPath={props.match.path} urlParams={parseQueryString(props)}/>
   },
 
   {

--- a/Client/src/Views/User/LoginRequiredDisclaimer.tsx
+++ b/Client/src/Views/User/LoginRequiredDisclaimer.tsx
@@ -5,6 +5,8 @@ import {User} from 'wdk-client/Utils/WdkUser';
 import {connect} from 'react-redux';
 
 interface OwnProps {
+  toDoWhatMessage?: string;
+  extraParagraphContent?: JSX.Element;
   children?: React.ReactChild
 }
 
@@ -25,7 +27,7 @@ const style: React.CSSProperties = {
 }
 
 function LoginRequiredDisclaimer(props: Props) {
-  const { user, children } = props;
+  const { user, toDoWhatMessage, extraParagraphContent, children } = props;
 
   if (window == null || user == null) return null;
 
@@ -36,7 +38,8 @@ function LoginRequiredDisclaimer(props: Props) {
     <div style={style}>
       <h3>It looks like you are not logged in.</h3>
       <p><i className="fa fa-user-o fa-5x"/></p>
-      <p>To use this page, please <Link to={`/user/login?destination=${destination}`}>log in</Link> or <Link to={`/user/registration`}>register</Link>.</p>
+      <p>{toDoWhatMessage || 'To use this page'}, please <Link to={`/user/login?destination=${destination}`}>log in</Link> or <Link to={`/user/registration`}>register</Link>.</p>
+      { extraParagraphContent }
     </div>
   );
 }

--- a/Client/src/Views/UserDatasets/MicrobiomeDBUploadForm.scss
+++ b/Client/src/Views/UserDatasets/MicrobiomeDBUploadForm.scss
@@ -16,6 +16,9 @@
     width: 100%;
     height: 8em;
   }
+  #data-set-url {
+    width: 100%;
+  }
   .formInfo {
     width: 80%;
     text-align: justify;

--- a/Client/src/Views/UserDatasets/UserDatasetsWorkspace.tsx
+++ b/Client/src/Views/UserDatasets/UserDatasetsWorkspace.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import WorkspaceNavigation from "wdk-client/Components/Workspace/WorkspaceNavigation";
 import { Route, Switch, Redirect } from "react-router";
+import WdkRoute from 'wdk-client/Core/WdkRoute';
 import UserDatasetListController from "wdk-client/Controllers/UserDatasetListController";
 import UserDatasetNewUploadController from "wdk-client/Controllers/UserDatasetNewUploadController";
 import { UserDatasetAllUploadsController } from "wdk-client/Controllers";
@@ -10,6 +11,7 @@ import { useWdkService } from "wdk-client/Hooks/WdkServiceHook";
 
 interface Props {
   rootPath: string;
+  urlParams: Record<string, string>
 };
 
 function UserDatasetsWorkspace(props: Props) {
@@ -48,19 +50,19 @@ function UserDatasetsWorkspace(props: Props) {
         ].flat()}
       />
       <Switch>
-        <Route exact path={rootPath}>
+        <WdkRoute exact requiresLogin path={rootPath} component={() =>
           <UserDatasetListController/>
-        </Route>
-       { hasDirectUpload && <Route exact path={`${rootPath}/new`}>
-						<UserDatasetNewUploadController/>
-        </Route> }
+          }/>
+        { hasDirectUpload && <WdkRoute requiresLogin exact path={`${rootPath}/new`} component={()=> 
+						<UserDatasetNewUploadController urlParams={props.urlParams}/>
+          }/> }
        
-    { hasDirectUpload && 		<Route exact path={`${rootPath}/recent`}>
+  { hasDirectUpload && 		<WdkRoute requiresLogin exact path={`${rootPath}/recent`} component={()=>
 						<UserDatasetAllUploadsController/>
-					</Route> }
-        <Route exact path={`${rootPath}/help`}>
+          }/> }
+          <WdkRoute exact requiresLogin={false} path={`${rootPath}/help`} component={()=>
           <UserDatasetHelp projectId={config.projectId} quotaSize={quotaSize}/>
-        </Route>
+          }/>
         <Redirect to={rootPath}/>
       </Switch>
     </div>

--- a/Client/src/Views/UserDatasets/UserDatasetsWorkspace.tsx
+++ b/Client/src/Views/UserDatasets/UserDatasetsWorkspace.tsx
@@ -52,17 +52,32 @@ function UserDatasetsWorkspace(props: Props) {
       <Switch>
         <WdkRoute exact requiresLogin path={rootPath} component={() =>
           <UserDatasetListController/>
-          }/>
+        } disclaimerProps={{toDoWhatMessage: "To view your datasets"}}/>
         { hasDirectUpload && <WdkRoute requiresLogin exact path={`${rootPath}/new`} component={()=> 
-						<UserDatasetNewUploadController urlParams={props.urlParams}/>
-          }/> }
-       
-  { hasDirectUpload && 		<WdkRoute requiresLogin exact path={`${rootPath}/recent`} component={()=>
-						<UserDatasetAllUploadsController/>
-          }/> }
-          <WdkRoute exact requiresLogin={false} path={`${rootPath}/help`} component={()=>
+          <UserDatasetNewUploadController urlParams={props.urlParams}/>
+          } disclaimerProps={{toDoWhatMessage: `To upload your dataset`, extraParagraphContent: ( Object.entries(props.urlParams).length == 0 ? undefined:
+            <div>
+              Afterwards, you will be taken back to an upload page with these details:
+              <ul style={{listStyle: "none"}}>
+              {Object.entries(props.urlParams).map(e => 
+                <li key={e.join(" ")}>
+                  {
+                    e[0].charAt(0).toUpperCase() + e[0].slice(1).replace("_", " ") + ": "
+                  }
+                  <code>{e[1]}</code>
+                </li>
+              )}
+               </ul>
+            </div>
+          ) }}/>
+        }
+        { hasDirectUpload && <WdkRoute requiresLogin exact path={`${rootPath}/recent`} component={()=>
+					<UserDatasetAllUploadsController/>
+          } disclaimerProps={{toDoWhatMessage: "To view your recent uploads"}}/>
+        }
+        <WdkRoute exact requiresLogin={false} path={`${rootPath}/help`} component={()=>
           <UserDatasetHelp projectId={config.projectId} quotaSize={quotaSize}/>
-          }/>
+        }/>
         <Redirect to={rootPath}/>
       </Switch>
     </div>


### PR DESCRIPTION
The main point of this PR is to support URLs like
```
https://wbazant.microbiomedb.org/mbio.wbazant/app/workspace/datasets/new?datasetName=Example%20biom&datasetSummary=A%20brief%20summary&datasetDescription=This%20is%20a%20small%20example%20file%20that%20I%20link%20to%20from%20the%20web&datasetUrl=https://raw.githubusercontent.com/biocore/biom-format/master/examples/rich_sparse_otu_table.biom
```
i.e. parameters `datasetName`, `datasetSummary`, `datasetDescription`, `datasetUrl`, so that our collaborators can make them. 

## Deployment
For this change to correctly work, a new handler needs to be deployed: https://github.com/VEuPathDB/dataset-handler-biom/pull/1
and end to end tested. If it doesn't work, 07200c551f53 is the commit that should be undone - the other two are not dependent on this change.

## Changes made
- Move the "you're not logged in" to under the user dataset options ribbon, and customise it for user datasets
- Use parameters from the URL to pre-fill the form
- Add an option to the MBio form: Data URL
- "Data File" and "Data URL" are a toggle, so the user can swap between them
![Screenshot from 2020-12-11 13-18-12](https://user-images.githubusercontent.com/16976512/101947479-8bc99100-3bbe-11eb-85c5-8b11f0443ebc.png)
![Screenshot from 2020-12-10 14-45-09](https://user-images.githubusercontent.com/16976512/101947471-8b30fa80-3bbe-11eb-9be3-6bee027b6593.png)
![Screenshot from 2020-12-10 14-45-44](https://user-images.githubusercontent.com/16976512/101947473-8b30fa80-3bbe-11eb-9cac-56129c83a3e2.png)
![Screenshot from 2020-12-10 14-48-55](https://user-images.githubusercontent.com/16976512/101947475-8bc99100-3bbe-11eb-8840-e71c593a54d2.png)
![Screenshot from 2020-12-10 14-52-46](https://user-images.githubusercontent.com/16976512/101947477-8bc99100-3bbe-11eb-8117-66f2ccefb107.png)





