### PR TITLE
When fetching param values from the param value store, use the service, not the wdkService cache, to retrieve the current user's id

### DIFF
--- a/Client/src/Utils/ParamValueStore.ts
+++ b/Client/src/Utils/ParamValueStore.ts
@@ -35,12 +35,12 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
     return _store.getItem(USER_ID_STORE_KEY);
   }
 
-  async function _checkServiceVersionAndUserId(): Promise<[number, number]> {
+  async function _checkServiceVersionAndUserId(options: { forceUser?: boolean } = {}): Promise<[number, number]> {
     const [ storeServiceVersion, storeUserId, currentServiceVersion, { id: currentUserId } ] = await Promise.all([
       _fetchServiceVersion(),
       _fetchUserId(),
       wdkService.getVersion(),
-      wdkService.getCurrentUser()
+      wdkService.getCurrentUser({ force: options.forceUser })
     ] as const);
 
     const serviceChanged = (
@@ -68,7 +68,7 @@ function makeInstance(serviceUrl: string, wdkService: WdkService): ParamValueSto
       return _store.clear();
     },
     fetchParamValues: async paramContext => {
-      await _checkServiceVersionAndUserId();
+      await _checkServiceVersionAndUserId({ forceUser: true });
 
       const storeKey = makeParamStoreKey(paramContext);
 


### PR DESCRIPTION
This PR addresses is a followup to https://github.com/VEuPathDB/WDKClient/pull/103. It is meant to address the case where the user has changed without a page reload.

For instance:

1. Go the GeneByLocusTag search page and run a search
2. Delete your JSESSIONID cookie
3. Revisit the GeneByLocusTag search page

Currently, this will NOT invalidate the `ParamValueStore`, as the user id is being retrieved using the cached version of `wdkService.getCurrentUser`. The fix is to update the `ParamValueStore`'s `fetchParamValues` method to use the uncached/forced version of `wdkService.getCurrentUser`.