### PR TITLE
Fetch with retry

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -63,7 +63,13 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-react": "^7.4.0",
     "ts-node": "^7.0.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "@testing-library/react-hooks": "^3.4.2",
+    "babel-jest": "^23.1.2",
+    "jest": "^23.4.2",
+    "jest-tap-reporter": "^1.9.0",
+    "react-test-renderer": "^16.9.0",
+    "ts-jest": "^23.1.2"
   },
   "jest": {
     "moduleNameMapper": {
@@ -85,13 +91,5 @@
     "reporters": [
       "jest-tap-reporter"
     ]
-  },
-  "optionalDependencies": {
-    "@testing-library/react-hooks": "^3.4.2",
-    "babel-jest": "^23.1.2",
-    "jest": "^23.4.2",
-    "jest-tap-reporter": "^1.9.0",
-    "react-test-renderer": "^16.9.0",
-    "ts-jest": "^23.1.2"
   }
 }

--- a/Client/src/Service/ServiceBase.ts
+++ b/Client/src/Service/ServiceBase.ts
@@ -1,16 +1,16 @@
-import { memoize } from 'lodash';
 import localforage from 'localforage';
+import { keyBy, memoize } from 'lodash';
 import * as QueryString from 'querystring';
 import { v4 as uuid } from 'uuid';
-
+import { expandedRecordClassDecoder } from 'wdk-client/Service/Decoders/RecordClassDecoders';
+import { ServiceError } from 'wdk-client/Service/ServiceError';
+import { fetchWithRetry } from 'wdk-client/Utils/FetchWithRetry';
 import * as Decode from 'wdk-client/Utils/Json';
 import { alert } from 'wdk-client/Utils/Platform';
 import { pendingPromise } from 'wdk-client/Utils/PromiseUtils';
-import { ServiceError } from 'wdk-client/Service/ServiceError';
 import { Question } from 'wdk-client/Utils/WdkModel';
-import { keyBy } from 'lodash';
-import { expandedRecordClassDecoder } from 'wdk-client/Service/Decoders/RecordClassDecoders';
 import { appendUrlAndRethrow } from './ServiceUtils';
+
 
 
 /**
@@ -182,7 +182,8 @@ export const ServiceBase = (serviceUrl: string) => {
   }
 
   function _fetchJson<T>(method: string, url: string, body?: string, isBaseUrl?: boolean) {
-    return fetch(
+    return fetchWithRetry(
+      1,
       isBaseUrl ? url : serviceUrl + url, 
       {
         method: method.toUpperCase(),

--- a/Client/src/Utils/FetchWithRetry.ts
+++ b/Client/src/Utils/FetchWithRetry.ts
@@ -1,0 +1,27 @@
+/**
+ * Execute a fetch request, with retry logic. `maxRetry` specifies the maximum number of times to retry the request.
+ * When this maximum is reached, any thrown errors are propagated to the caller.
+ * There is a delay between tries in an attempt to allow external conditions to settle.
+ */
+export async function fetchWithRetry(
+  maxRetry: number,
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  for (let i = 0; i < maxRetry; i++) {
+    try {
+      return await fetch(input, appendRetryHeader(i, init));
+    }
+    catch {
+      // Add a delay in case the user's network is in a temporary bad state.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  return fetch(input, appendRetryHeader(maxRetry, init));
+}
+
+function appendRetryHeader(retryNum: number, init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers ?? ({} as HeadersInit));
+  headers.append("x-client-retry-count", retryNum.toString());
+  return { ...init, headers };
+}


### PR DESCRIPTION
This PR introduces a utility to make fetch requests with retry logic: `fetchWithRetry`. The utility accepts a `maxRetry` argument, which is the maximum number of times a fetch operation is retried. A timeout of 250ms is applied before each retry. If the operation fails after the last retry, the error will propagate to the caller, as usual. A custom header (`x-client-retry-count`) is included in each request, which can be useful for backend logging.

The utility is applied the `WdkService` module with a `maxRetry` value of `1`. There are other uses of `window.fetch` which we can apply this utility, but for now we will only apply it to the core `WdkService` fetch logic and monitor `Failed to fetch` errors.