### PR TITLE
Checkbox component: add missing "onChange" dependency

### DIFF
--- a/Client/src/Components/InputControls/Checkbox.tsx
+++ b/Client/src/Components/InputControls/Checkbox.tsx
@@ -25,7 +25,7 @@ const Checkbox = (props: Props) => {
   } = props;
   let changeHandler = useCallback((_event: React.FormEvent<HTMLInputElement>) => {
     onChange(!value);
-  }, [ value ]);
+  }, [ value, onChange ]);
 
   return (
     <input


### PR DESCRIPTION
This PR adds `onChange` as a dependency to the `useCallback` which derives the checkbox's `changeHandler`. It is necessary to handle the case where the `onChange` prop is not referentially stable.

(Such as [this reporter form](https://github.com/VEuPathDB/EbrcWebsiteCommon/blob/master/Site/webapp/wdkCustomization/js/client/components/reporters/FastaOrthoSequenceReporterForm.jsx), where the bug was first observed.)