### PR TITLE
Client Plugins: allow paramName context

### DIFF
--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -165,6 +165,7 @@ function QuestionController(props: Props) {
         context={{
           type: 'questionFormParameter',
           name: parameter.name,
+          paramName: parameter.name,
           searchName,
           recordClassName
         }}

--- a/Client/src/Controllers/RecordController.tsx
+++ b/Client/src/Controllers/RecordController.tsx
@@ -19,8 +19,9 @@ import {
 } from 'wdk-client/Actions/RecordActions';
 
 import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
+import { stripHTML } from 'wdk-client/Utils/DomUtils';
 import { RecordClass } from 'wdk-client/Utils/WdkModel';
-import { PartialRecordRequest, getAttributeNames, getTableNames, stripHTML } from 'wdk-client/Views/Records/RecordUtils';
+import { PartialRecordRequest, getAttributeNames, getTableNames } from 'wdk-client/Views/Records/RecordUtils';
 import { RootState } from 'wdk-client/Core/State/Types';
 
 const ActionCreators = {

--- a/Client/src/Utils/ClientPlugin.tsx
+++ b/Client/src/Utils/ClientPlugin.tsx
@@ -160,14 +160,6 @@ function isMatchingEntry<T>(entry: ClientPluginRegistryEntry<T>, context: Plugin
   return true;
 }
 
-function isResolved(context: PluginEntryContext, references: ResolvedPluginReferences) {
-  const { searchName, recordClassName } = context;
-  const { question, recordClass } = references;
-  const isSearchResolved = searchName == null ? true : question != null;
-  const isRecordClassResolved = recordClassName == null ? true : recordClass != null;
-  return isSearchResolved && isRecordClassResolved;
-}
-
 // Default implementations
 function DefaultPluginComponent() {
   return null;

--- a/Client/src/Utils/ClientPlugin.tsx
+++ b/Client/src/Utils/ClientPlugin.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react';
 import { defaultMemoize } from 'reselect';
-import { RecordClass, Question } from 'wdk-client/Utils/WdkModel';
-import { useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
-import NotFound from 'wdk-client/Views/NotFound/NotFound';
 import LoadError from 'wdk-client/Components/PageStatus/LoadError';
+import { WdkService } from 'wdk-client/Core';
+import { useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
+import { Parameter, Question, RecordClass } from 'wdk-client/Utils/WdkModel';
+import NotFound from 'wdk-client/Views/NotFound/NotFound';
 
 export type PluginType =
   | 'attributeAnalysis'
@@ -23,6 +24,7 @@ export interface PluginEntryContext {
   name?: string;
   recordClassName?: string;
   searchName?: string;
+  paramName?: string;
 }
 
 type CompositePluginComponentProps<PluginProps> = {
@@ -34,6 +36,7 @@ type CompositePluginComponentProps<PluginProps> = {
 type ResolvedPluginReferences = {
   recordClass?: RecordClass;
   question?: Question;
+  parameter?: Parameter;
 }
 
 type PluginComponent<PluginProps> = React.ComponentType<PluginProps>;
@@ -92,17 +95,17 @@ function makeCompositePluginComponentUncached<T>(registry: ClientPluginRegistryE
   function CompositePluginComponent(props: Props) {
     const resolvedReferences = useWdkService(async wdkService => {
       try {
-        const { searchName, recordClassName } = props.context;
-        const [ question, recordClass ] = await Promise.all([
-          searchName == null ? undefined : wdkService.findQuestion(searchName),
+        const { searchName, recordClassName, paramName } = props.context;
+        const [ { parameter, question }, recordClass ] = await Promise.all([
+          resolveQuestionAndParameter(wdkService, searchName, paramName),
           recordClassName == null ? undefined : wdkService.findRecordClass(recordClassName)
         ]);
-        return { question, recordClass };
+        return { parameter, question, recordClass };
       }
       catch (error) {
         return { error };
       }
-    }, [ props.context.searchName, props.context.recordClassName ]);
+    }, [ props.context.paramName, props.context.searchName, props.context.recordClassName ]);
 
     if (resolvedReferences == null) return null;
 
@@ -123,6 +126,30 @@ function makeCompositePluginComponentUncached<T>(registry: ClientPluginRegistryE
 
 // We should only re-create the composite plugin component if the plugin registry has changed
 export const makeCompositePluginComponent = defaultMemoize(makeCompositePluginComponentUncached);
+
+async function resolveQuestionAndParameter(wdkService: WdkService, searchName?: string, paramName?: string) {
+  if (searchName == null) {
+    return {
+      parameter: undefined,
+      question: undefined
+    };
+  }
+
+  if (paramName === null) {
+    return {
+      parameter: undefined,
+      question: await wdkService.findQuestion(searchName)
+    };
+  }
+
+  const question = await wdkService.getQuestionAndParameters(searchName);
+  const parameter = question?.parameters.find(({ name }) => name === paramName);
+
+  return {
+    parameter,
+    question
+  };
+}
 
 function isMatchingEntry<T>(entry: ClientPluginRegistryEntry<T>, context: PluginEntryContext, references: ResolvedPluginReferences): boolean {
   if (entry.type !== context.type) return false;

--- a/Client/src/Utils/DomUtils.ts
+++ b/Client/src/Utils/DomUtils.ts
@@ -281,3 +281,12 @@ function writeText(str: string): Promise<void> {
     success ? resolve(): reject();
   });
 }
+
+/**
+ * Strip HTML characters from a string.
+ */
+export function stripHTML(str: string): string {
+  let span = document.createElement('span');
+  span.innerHTML = str;
+  return span.textContent || '';
+}

--- a/Client/src/Views/Records/RecordUtils.ts
+++ b/Client/src/Views/Records/RecordUtils.ts
@@ -1,6 +1,7 @@
 import { partial, pick, values } from 'lodash';
 
 import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
+import { stripHTML } from 'wdk-client/Utils/DomUtils';
 import { Seq } from 'wdk-client/Utils/IterableUtils';
 import { getPropertyValue, nodeHasProperty } from 'wdk-client/Utils/OntologyUtils';
 import { filterItems } from 'wdk-client/Utils/SearchUtils';
@@ -28,15 +29,6 @@ export function filterRecords(records: RecordInstance[], filterSpec: FilterSpec)
   let { filterTerm, filterAttributes = [], filterTables = [] } = filterSpec;
   let getSearchableStringPartial = partial(getSearchableString, filterAttributes, filterTables);
   return filterItems(records, getSearchableStringPartial, filterTerm);
-}
-
-/**
- * Strip HTML characters from a string.
- */
-export function stripHTML(str: string): string {
-  let span = document.createElement('span');
-  span.innerHTML = str;
-  return span.textContent || '';
 }
 
 /**


### PR DESCRIPTION
This PR updates the interface for the client `PluginContext` so that a `paramName` of interest can be provided. In this case, the `parameter` with that specified `paramName` will be included among the `ResolvedReferences` that are passed to client plugin `test` predicates.

In particular, this allows us to consult a parameter's property lists in `test` predicates for plugins of type `questionFormParameter`.

**Note:** In addition, the `stripHTML` utility is moved to a more generic directory, as it will be repurposed in a related `EbrcWebsiteCommon` PR.

**Future work:** Consider making `PluginContext` and `ResolvedReferences` "parametrizable," perhaps based on the `PluginType`.