### PR TITLE
Download Form: two bugfixes concerning initially selected attributes

### DIFF
--- a/Client/src/Views/ReporterForm/WdkServiceJsonReporterForm.tsx
+++ b/Client/src/Views/ReporterForm/WdkServiceJsonReporterForm.tsx
@@ -6,7 +6,14 @@ import { Ontology } from 'wdk-client/Utils/OntologyUtils';
 import { Question, RecordClass } from 'wdk-client/Utils/WdkModel';
 import { State } from 'wdk-client/StoreModules/DownloadFormStoreModule';
 import ReporterSortMessage from 'wdk-client/Views/ReporterForm/ReporterSortMessage';
-import { addPk, getAttributesChangeHandler, getAttributeSelections, getAttributeTree, getTableTree } from 'wdk-client/Views/ReporterForm/reporterUtils';
+import {
+  addPk,
+  getAttributesChangeHandler,
+  getAttributeSelections,
+  getAttributeTree,
+  getTableTree,
+  getAllReportScopedAttributes
+} from 'wdk-client/Views/ReporterForm/reporterUtils';
 
 type Props<T, U> = {
   scope: string;
@@ -81,9 +88,15 @@ namespace WdkServiceJsonReporterForm {
 
     // select all attribs and tables for record page, else column user prefs and no tables
     else {
+      let allReportScopedAttrs = getAllReportScopedAttributes(
+        ontology,
+        recordClass.fullName,
+        question
+      );
+
       attribs = (scope === 'results' ?
-        addPk(getAttributeSelections(preferences, question), recordClass) :
-        addPk(getAllLeafIds(getAttributeTree(ontology, recordClass.fullName, question)), recordClass));
+        addPk(getAttributeSelections(preferences, question, allReportScopedAttrs), recordClass) :
+        addPk(allReportScopedAttrs, recordClass));
       tables = (scope === 'results' ? [] :
         getAllLeafIds(getTableTree(ontology, recordClass.fullName)));
     }

--- a/Client/src/Views/ReporterForm/WdkServiceJsonReporterForm.tsx
+++ b/Client/src/Views/ReporterForm/WdkServiceJsonReporterForm.tsx
@@ -8,11 +8,11 @@ import { State } from 'wdk-client/StoreModules/DownloadFormStoreModule';
 import ReporterSortMessage from 'wdk-client/Views/ReporterForm/ReporterSortMessage';
 import {
   addPk,
-  getAttributesChangeHandler,
+  getAllReportScopedAttributes,
   getAttributeSelections,
   getAttributeTree,
+  getAttributesChangeHandler,
   getTableTree,
-  getAllReportScopedAttributes
 } from 'wdk-client/Views/ReporterForm/reporterUtils';
 
 type Props<T, U> = {


### PR DESCRIPTION
This PR has two bugfixes related to initially selected attributes on download forms:

1. `getAttributeSelections`: fix a logic error that was causing the associated summary user preferences to not be retrieved (the necessary user preference was being looked up at `userPrefs` instead of `userPrefs.project`)
2. `WdkServiceJsonReporterForm`: preselect attributes as in other download forms (currently, no non-primary-key attributes are preselected)

Future [EbrcWebsiteCommon](https://github.com/VEuPathDB/EbrcWebsiteCommon) cleanup: DRY up the existing download forms with the new `getAllReportScopedAttributes` utility.