### PR TITLE
Make TreeBoxEnumParam logic reusable

### DIFF
--- a/Client/src/Components/CheckboxTree/CheckboxTree.tsx
+++ b/Client/src/Components/CheckboxTree/CheckboxTree.tsx
@@ -35,7 +35,7 @@ let Bar = () => <span> | </span>;
 
 type ChangeHandler = (ids: string[]) => void;
 
-type Props<T> = {
+export type Props<T> = {
 
   //%%%%%%%%%%% Basic expandable tree props %%%%%%%%%%%
 

--- a/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -3,7 +3,7 @@ import 'wdk-client/Views/Question/Params/TreeBoxParam.scss';
 import { intersection } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
 
-import CheckboxTree from 'wdk-client/Components/CheckboxTree/CheckboxTree';
+import CheckboxTree, { Props as CheckboxTreeProps } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
 import { Seq } from 'wdk-client/Utils/IterableUtils';
@@ -39,6 +39,7 @@ export type TreeBoxProps = {
   uiState: State;
   context: Context<TreeBoxEnumParam>;
   dispatch: DispatchAction;
+  wrapCheckboxTreeProps?: (props: CheckboxTreeProps<TreeBoxVocabNode>) => CheckboxTreeProps<TreeBoxVocabNode>;
 }
 
 
@@ -151,11 +152,14 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
   );
 
   const checkboxTreeProps = useDefaultCheckboxTreeProps(props, tree, selectedLeaves);
+  const wrappedCheckboxTreeProps = props.wrapCheckboxTreeProps == null
+    ? checkboxTreeProps
+    : props.wrapCheckboxTreeProps(checkboxTreeProps);
 
   return (
     <div className="wdk-TreeBoxParam">
       <SelectionInfo parameter={props.parameter} {...selectionCounts} alwaysShowCount />
-      <CheckboxTree {...checkboxTreeProps} />
+      <CheckboxTree {...wrappedCheckboxTreeProps} />
     </div>
   );
 }

--- a/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -32,7 +32,7 @@ export type State = {
   searchTerm: string;
 }
 
-type TreeBoxProps = {
+export type TreeBoxProps = {
   parameter: TreeBoxEnumParam;
   selectedValues: string[];
   onChange: (newValue: string[]) => void;

--- a/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -1,7 +1,7 @@
 import 'wdk-client/Views/Question/Params/TreeBoxParam.scss';
 
 import { intersection } from 'lodash';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import CheckboxTree from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
@@ -141,11 +141,15 @@ export function reduce(state: State = {} as State, action: Action): State {
 export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
   const tree = props.parameter.vocabulary;
   const selectedNodes = props.selectedValues;
-  const selectedLeaves = removeBranches(tree, selectedNodes);
-  const allCount = getLeaves(tree, getNodeChildren).length;
-  const selectedCount = props.parameter.countOnlyLeaves
-    ? selectedLeaves.length
-    : selectedNodes.length;
+  const selectedLeaves = useSelectedLeaves(tree, selectedNodes);
+
+  const allCount = useAllCount(tree);
+  const selectedCount = findSelectedCount(
+    props.parameter.countOnlyLeaves,
+    selectedLeaves.length,
+    selectedNodes.length
+  );
+
   const handleExpansionChange = useCallback((expandedList: string[]) => {
     props.dispatch(setExpandedList({ ...props.context, expandedList }));
   }, [props.dispatch, props.context])
@@ -200,3 +204,27 @@ function renderNoResults(searchTerm: string) {
 }
 
 export default TreeBoxEnumParamComponent;
+
+export function useSelectedLeaves(tree: TreeBoxVocabNode, selectedNodes: string[]) {
+  return useMemo(
+    () => removeBranches(tree, selectedNodes),
+    [ tree, selectedNodes ]
+  );
+}
+
+export function useAllCount(tree: TreeBoxVocabNode) {
+  return useMemo(
+    () => getLeaves(tree, getNodeChildren).length,
+    []
+  );
+}
+
+export function findSelectedCount(
+  countOnlyLeaves: boolean,
+  selectedLeavesCount: number,
+  selectedNodesCount: number
+) {
+  return countOnlyLeaves
+    ? selectedLeavesCount
+    : selectedNodesCount;
+}


### PR DESCRIPTION
This PR moves the rendering logic for the `TreeBoxEnumParam` component into reusable hooks.

Motivating use case: for "organism" params, we want to override a handful of props that are passed to the underlying `CheckboxTree` (most notably `renderNode` and `searchPredicate`).