### PR TITLE
Add prop to configure prefix of filtered heading

### DIFF
--- a/Client/src/Components/AttributeFilter/MembershipField.jsx
+++ b/Client/src/Components/AttributeFilter/MembershipField.jsx
@@ -124,6 +124,10 @@ class MembershipField extends React.PureComponent {
 
 }
 
+MembershipField.defaultProps = {
+  filteredCountHeadingPrefix: 'Remaining',
+}
+
 function filterBySearchTerm(rows, searchTerm){
   if (searchTerm !== ''){
     let re = new RegExp(escapeRegExp(searchTerm), 'i');
@@ -457,7 +461,7 @@ class MembershipTable extends React.PureComponent {
   }
 
   renderFilteredCountHeading1() {
-    return this.renderCountHeading1('Remaining');
+    return this.renderCountHeading1(this.props.filteredCountHeadingPrefix);
   }
 
   renderFilteredCountHeading2() {


### PR DESCRIPTION
This PR allows the prefix used for the table heading for the filtered count column to be configured. It defaults to *Remaining*, so we can try some things out on select sites before making a global change.