### PR TITLE
When deleting a nested root step, don't delete the other slots of the nested strategy

### DIFF
--- a/Client/src/Actions/StrategyActions.ts
+++ b/Client/src/Actions/StrategyActions.ts
@@ -118,7 +118,7 @@ export const fulfillGetDuplicatedStrategyStepTree = makeActionCreator(
 
 export const requestRemoveStepFromStepTree = makeActionCreator(
     'requestRemoveStepFromStepTree',
-    (strategyId: number, stepIdToRemove: number, stepTree: StepTree) => ({ strategyId, stepIdToRemove, stepTree })
+    (strategyId: number, stepIdToRemove: number, stepTree: StepTree, isNestedControlStep: boolean = false) => ({ strategyId, stepIdToRemove, stepTree, isNestedControlStep })
 )
 
 export const requestUpdateStepProperties = makeActionCreator(

--- a/Client/src/Actions/StrategyActions.ts
+++ b/Client/src/Actions/StrategyActions.ts
@@ -118,7 +118,7 @@ export const fulfillGetDuplicatedStrategyStepTree = makeActionCreator(
 
 export const requestRemoveStepFromStepTree = makeActionCreator(
     'requestRemoveStepFromStepTree',
-    (strategyId: number, stepIdToRemove: number, stepTree: StepTree, isNestedControlStep: boolean = false) => ({ strategyId, stepIdToRemove, stepTree, isNestedControlStep })
+    (strategyId: number, stepIdToRemove: number, stepTree: StepTree, deleteSubtree: boolean = false) => ({ strategyId, stepIdToRemove, stepTree, deleteSubtree })
 )
 
 export const requestUpdateStepProperties = makeActionCreator(

--- a/Client/src/Controllers/StrategyPanelController.tsx
+++ b/Client/src/Controllers/StrategyPanelController.tsx
@@ -49,7 +49,7 @@ interface MappedDispatch {
   onAnalyzeStep: () => void;
   onMakeNestedStrategy: (branchStepId: number) => void;
   onMakeUnnestedStrategy: (branchStepId: number) => void;
-  onDeleteStep: (stepTree: StepTree, stepId: number, isNestedControlStep?: boolean) => void;
+  onDeleteStep: (stepTree: StepTree, stepId: number, deleteSubtree?: boolean) => void;
 }
 
 type Props = OwnProps & MappedProps & MappedDispatch;
@@ -105,7 +105,7 @@ function mapDispatchToProps(dispatch: Dispatch, props: OwnProps): MappedDispatch
     }),
     onMakeNestedStrategy: (branchStepId: number) => nestStrategy(viewId, branchStepId),
     onMakeUnnestedStrategy: (branchStepId: number) => unnestStrategy(viewId, branchStepId),
-    onDeleteStep: (stepTree: StepTree, stepId: number, isNestedControlStep: boolean = false) => requestRemoveStepFromStepTree(strategyId, stepId, stepTree, isNestedControlStep)
+    onDeleteStep: (stepTree: StepTree, stepId: number, deleteSubtree: boolean = false) => requestRemoveStepFromStepTree(strategyId, stepId, stepTree, deleteSubtree)
   }, dispatch);
 }
 

--- a/Client/src/Controllers/StrategyPanelController.tsx
+++ b/Client/src/Controllers/StrategyPanelController.tsx
@@ -49,7 +49,7 @@ interface MappedDispatch {
   onAnalyzeStep: () => void;
   onMakeNestedStrategy: (branchStepId: number) => void;
   onMakeUnnestedStrategy: (branchStepId: number) => void;
-  onDeleteStep: (stepTree: StepTree, stepId: number) => void;
+  onDeleteStep: (stepTree: StepTree, stepId: number, isNestedControlStep?: boolean) => void;
 }
 
 type Props = OwnProps & MappedProps & MappedDispatch;
@@ -105,7 +105,7 @@ function mapDispatchToProps(dispatch: Dispatch, props: OwnProps): MappedDispatch
     }),
     onMakeNestedStrategy: (branchStepId: number) => nestStrategy(viewId, branchStepId),
     onMakeUnnestedStrategy: (branchStepId: number) => unnestStrategy(viewId, branchStepId),
-    onDeleteStep: (stepTree: StepTree, stepId: number) => requestRemoveStepFromStepTree(strategyId, stepId, stepTree)
+    onDeleteStep: (stepTree: StepTree, stepId: number, isNestedControlStep: boolean = false) => requestRemoveStepFromStepTree(strategyId, stepId, stepTree, isNestedControlStep)
   }, dispatch);
 }
 

--- a/Client/src/StoreModules/StrategyStoreModule.ts
+++ b/Client/src/StoreModules/StrategyStoreModule.ts
@@ -430,10 +430,10 @@ async function getFulfillStrategy_SaveAs(
     state$: StateObservable<RootState>,
     { wdkService }: EpicDependencies
   ): Promise<InferAction<typeof requestPutStrategyStepTree | typeof requestDeleteStrategy>> {
-    const { strategyId, stepIdToRemove, stepTree, isNestedControlStep } = requestAction.payload;
+    const { strategyId, stepIdToRemove, stepTree, deleteSubtree } = requestAction.payload;
     // First, we have to remove the step from the step tree, and then
     // we have to delete the step.
-    const newStepTree = removeStep(stepTree, stepIdToRemove, isNestedControlStep);
+    const newStepTree = removeStep(stepTree, stepIdToRemove, deleteSubtree);
     return newStepTree ? requestPutStrategyStepTree(strategyId, newStepTree) : requestDeleteStrategy(strategyId);
     // const removedSteps = difference(
     //   getStepIds(stepTree),

--- a/Client/src/StoreModules/StrategyStoreModule.ts
+++ b/Client/src/StoreModules/StrategyStoreModule.ts
@@ -430,10 +430,10 @@ async function getFulfillStrategy_SaveAs(
     state$: StateObservable<RootState>,
     { wdkService }: EpicDependencies
   ): Promise<InferAction<typeof requestPutStrategyStepTree | typeof requestDeleteStrategy>> {
-    const { strategyId, stepIdToRemove, stepTree } = requestAction.payload;
+    const { strategyId, stepIdToRemove, stepTree, isNestedControlStep } = requestAction.payload;
     // First, we have to remove the step from the step tree, and then
     // we have to delete the step.
-    const newStepTree = removeStep(stepTree, stepIdToRemove);
+    const newStepTree = removeStep(stepTree, stepIdToRemove, isNestedControlStep);
     return newStepTree ? requestPutStrategyStepTree(strategyId, newStepTree) : requestDeleteStrategy(strategyId);
     // const removedSteps = difference(
     //   getStepIds(stepTree),

--- a/Client/src/Utils/StrategyUtils.ts
+++ b/Client/src/Utils/StrategyUtils.ts
@@ -287,7 +287,7 @@ export const findPrimaryBranchLeaf = (stepTree: StepTree): StepTree =>
 export const removeStep = (
   stepTree: StepTree,
   targetStepId: number,
-  isNestedControlStep: boolean = false
+  deleteSubtree: boolean = false
 ): StepTree | undefined => {
   return _recurse(stepTree);
 
@@ -302,11 +302,11 @@ export const removeStep = (
 
     // Remove a step which is the secondary input of the stepTree's root
     if (stepTree.secondaryInput?.stepId === targetStepId) {
-      // If the target is a secondary leaf of stepTree's root, or a nested control step,
+      // If the target is a secondary leaf of stepTree's root, or deleteSubtree is true,
       // return the primary input of stepTree (that is, "delete every step of the nested strategy, not just the target")
       if (
         stepTree.secondaryInput.primaryInput == null ||
-        isNestedControlStep
+        deleteSubtree
       ) {
         return stepTree.primaryInput;
       }
@@ -326,7 +326,7 @@ export const removeStep = (
         stepTree.primaryInput.stepId === targetStepId ||
         (
           stepTree.primaryInput.secondaryInput?.stepId === targetStepId &&
-          isNestedControlStep
+          deleteSubtree
         )
       )
     ) {

--- a/Client/src/Utils/StrategyUtils.ts
+++ b/Client/src/Utils/StrategyUtils.ts
@@ -284,31 +284,52 @@ export const findPrimaryBranchLeaf = (stepTree: StepTree): StepTree =>
  * removal of the target step is a valid operation, or b) that code downstream
  * of this function will handle invalid step trees.
  */
-export const removeStep = (stepTree: StepTree, targetStepId: number): StepTree | undefined => {
+export const removeStep = (
+  stepTree: StepTree,
+  targetStepId: number,
+  isNestedControlStep: boolean = false
+): StepTree | undefined => {
   return _recurse(stepTree);
 
   function _recurse(stepTree: StepTree | undefined): StepTree | undefined {
     if (stepTree == null) return stepTree;
 
-    // Remove a step from head position if a strategy (e.g., a root step)
-    // Return its primary input
-    if (
-      stepTree.stepId === targetStepId ||
-      (stepTree.secondaryInput && stepTree.secondaryInput.stepId === targetStepId)
-    ) {
+    // Remove a step which the root of the stepTree
+    // In this case, return its primary input
+    if (stepTree.stepId === targetStepId) {
       return stepTree.primaryInput;
     }
-    
+
+    // Remove a step which is the secondary input of the stepTree's root
+    if (stepTree.secondaryInput?.stepId === targetStepId) {
+      // If the target is a secondary leaf of stepTree's root, or a nested control step,
+      // return the primary input of stepTree (that is, "delete every step of the nested strategy, not just the target")
+      if (
+        stepTree.secondaryInput.primaryInput == null ||
+        isNestedControlStep
+      ) {
+        return stepTree.primaryInput;
+      }
+
+      // Otherwise, replace the target with its primary input
+      return {
+        ...stepTree,
+        secondaryInput: stepTree.secondaryInput.primaryInput
+      };
+    }
+
     // Remove a step from non-head position of a strategy.
     // Replace the primary input for which it is the primary input with its primary input.
     if (
       stepTree.primaryInput != null &&
       (
-        (stepTree.primaryInput.stepId === targetStepId) ||
-        (stepTree.primaryInput.secondaryInput && stepTree.primaryInput.secondaryInput.stepId === targetStepId)
+        stepTree.primaryInput.stepId === targetStepId ||
+        (
+          stepTree.primaryInput.secondaryInput?.stepId === targetStepId &&
+          isNestedControlStep
+        )
       )
     ) {
-
       return stepTree.primaryInput.primaryInput == null
         ? stepTree.secondaryInput
         : {
@@ -321,7 +342,7 @@ export const removeStep = (stepTree: StepTree, targetStepId: number): StepTree |
       ...stepTree,
       primaryInput: _recurse(stepTree.primaryInput),
       secondaryInput: _recurse(stepTree.secondaryInput)
-    }
+    };
   }
 }
 

--- a/Client/src/Utils/__tests__/StrategyUtilsTest.ts
+++ b/Client/src/Utils/__tests__/StrategyUtilsTest.ts
@@ -182,7 +182,7 @@ describe('removeStep', () => {
       }
     };
 
-    it('should remove the entire nested strategy, if isNestedControlStep is true', () => {
+    it('should remove the entire nested strategy, if deleteSubtree is true', () => {
       //    8 -> 7
       //         |
       //         v
@@ -226,7 +226,7 @@ describe('removeStep', () => {
       expect(removeStep(stepTree, 7, true)).toEqual(resultStepTree2);
     });
 
-    it('should preserve the other steps of the nested strategy, if isNestedControlStep is false', () => {
+    it('should preserve the other steps of the nested strategy, if deleteSubtree is false', () => {
       //     8 -> 7        6
       //          |        |
       //          v        v

--- a/Client/src/Utils/__tests__/StrategyUtilsTest.ts
+++ b/Client/src/Utils/__tests__/StrategyUtilsTest.ts
@@ -148,6 +148,141 @@ describe('removeStep', () => {
 
     });
   });
+
+  describe('with a nested strategy root target', () => {
+    //                   9
+    //                   |
+    //                   v
+    //     8 -> 7   6 -> 5
+    //          |        |
+    //          v        v
+    // 3 -----> 2 -----> 1
+    const stepTree: StepTree = {
+      stepId: 1,
+      primaryInput: {
+        stepId: 2,
+        primaryInput: {
+          stepId: 3
+        },
+        secondaryInput: {
+          stepId: 7,
+          primaryInput: {
+            stepId: 8
+          }
+        }
+      },
+      secondaryInput: {
+        stepId: 5,
+        primaryInput: {
+          stepId: 6
+        },
+        secondaryInput: {
+          stepId: 9
+        }
+      }
+    };
+
+    it('should remove the entire nested strategy, if isNestedControlStep is true', () => {
+      //    8 -> 7
+      //         |
+      //         v
+      // 3 ----> 2
+      const resultStepTree1: StepTree = {
+        stepId: 2,
+        primaryInput: {
+          stepId: 3
+        },
+        secondaryInput: {
+          stepId: 7,
+          primaryInput: {
+            stepId: 8
+          }
+        }
+      };
+      expect(removeStep(stepTree, 5, true)).toEqual(resultStepTree1);
+
+      //          9
+      //          |
+      //          v
+      //     6 -> 5
+      //          |
+      //          v
+      // 3 -----> 1
+      const resultStepTree2: StepTree = {
+        stepId: 1,
+        primaryInput: {
+          stepId: 3
+        },
+        secondaryInput: {
+          stepId: 5,
+          primaryInput: {
+            stepId: 6
+          },
+          secondaryInput: {
+            stepId: 9
+          }
+        }
+      };
+      expect(removeStep(stepTree, 7, true)).toEqual(resultStepTree2);
+    });
+
+    it('should preserve the other steps of the nested strategy, if isNestedControlStep is false', () => {
+      //     8 -> 7        6
+      //          |        |
+      //          v        v
+      // 3 -----> 2 -----> 1
+      const resultStepTree1: StepTree = {
+        stepId: 1,
+        primaryInput: {
+          stepId: 2,
+          primaryInput: {
+            stepId: 3
+          },
+          secondaryInput: {
+            stepId: 7,
+            primaryInput: {
+              stepId: 8
+            }
+          }
+        },
+        secondaryInput: {
+          stepId: 6
+        }
+      };
+      expect(removeStep(stepTree, 5, false)).toEqual(resultStepTree1);
+
+      //                   9
+      //                   |
+      //                   v
+      //          8   6 -> 5
+      //          |        |
+      //          v        v
+      // 3 -----> 2 -----> 1
+      const resultStepTree2: StepTree = {
+        stepId: 1,
+        primaryInput: {
+          stepId: 2,
+          primaryInput: {
+            stepId: 3
+          },
+          secondaryInput: {
+            stepId: 8
+          }
+        },
+        secondaryInput: {
+          stepId: 5,
+          primaryInput: {
+            stepId: 6
+          },
+          secondaryInput: {
+            stepId: 9
+          }
+        }
+      };
+      expect(removeStep(stepTree, 7, false)).toEqual(resultStepTree2);
+
+    });
+  });
 })
 
 describe('addStep', () => {

--- a/Client/src/Views/Strategy/StepBoxes.tsx
+++ b/Client/src/Views/Strategy/StepBoxes.tsx
@@ -153,7 +153,7 @@ function StepTree(props: StepBoxesProps) {
                     props.onShowInsertStep({ type: 'insert-before', stepId: step.id, selectedOperation, pageHistory }),
                   insertStepAfter: (selectedOperation?: string, pageHistory?: string[]) => 
                     props.onShowInsertStep({ type: 'append', stepId: secondaryInput.step.id, selectedOperation, pageHistory }),
-                  deleteStep: () => props.onDeleteStep(step.id)
+                  deleteStep: () => props.onDeleteStep(step.id, secondaryInput.isNested)
                 }}
                 defaultComponent={StepBox}
               />

--- a/Client/src/Views/Strategy/StrategyPanel.tsx
+++ b/Client/src/Views/Strategy/StrategyPanel.tsx
@@ -37,7 +37,7 @@ interface Props {
   onRenameStep: (stepId: number, newName: string) => void;
   onRenameNestedStrategy: (branchStepId: number, newName: string) => void;
   onAnalyzeStep: () => void;
-  onDeleteStep: (stepId: number) => void;
+  onDeleteStep: (stepId: number, isNestedControlStep?: boolean) => void;
 }
 
 export default function StrategyPanel(props: Props) {

--- a/Client/src/Views/Strategy/StrategyPanel.tsx
+++ b/Client/src/Views/Strategy/StrategyPanel.tsx
@@ -37,7 +37,7 @@ interface Props {
   onRenameStep: (stepId: number, newName: string) => void;
   onRenameNestedStrategy: (branchStepId: number, newName: string) => void;
   onAnalyzeStep: () => void;
-  onDeleteStep: (stepId: number, isNestedControlStep?: boolean) => void;
+  onDeleteStep: (stepId: number, deleteSubtree?: boolean) => void;
 }
 
 export default function StrategyPanel(props: Props) {

--- a/Client/src/Views/Strategy/Types.ts
+++ b/Client/src/Views/Strategy/Types.ts
@@ -83,7 +83,7 @@ export interface StepBoxesProps {
   onRenameStep: (stepId: number, newName: string) => void;
   onRenameNestedStrategy: (branchStepId: number, newName: string) => void;
   onAnalyzeStep: () => void;
-  onDeleteStep: (stepId: number, isNestedControlStep?: boolean) => void;
+  onDeleteStep: (stepId: number, deleteSubtree?: boolean) => void;
 }
 
 export interface StepBoxProps<T extends UiStepTree = UiStepTree> {

--- a/Client/src/Views/Strategy/Types.ts
+++ b/Client/src/Views/Strategy/Types.ts
@@ -83,7 +83,7 @@ export interface StepBoxesProps {
   onRenameStep: (stepId: number, newName: string) => void;
   onRenameNestedStrategy: (branchStepId: number, newName: string) => void;
   onAnalyzeStep: () => void;
-  onDeleteStep: (stepId: number) => void;
+  onDeleteStep: (stepId: number, isNestedControlStep?: boolean) => void;
 }
 
 export interface StepBoxProps<T extends UiStepTree = UiStepTree> {


### PR DESCRIPTION
This PR fixes a bug where, when deleting the root step of a nested strategy, the entire nested strategy is deleted. (See attached image.)

The issue is that roots of nested steps have two associated "step details" dialogs - one displaying a summary of the nested strategy (which can be view by opening details for the "nested control step"), and one displaying the results for the root step itself. For the former, clicking "delete" should delete the entire nested strategy; for the latter, clicking "delete" should delete only the slot with the nested root step. Currently, clicking "delete" on either of these dialogs causes the entire nested strategy to be deleted.

To address this issue, I add, to the `removeStep` utility, an optional `isNestedControlStep` argument. When `true`, this argument signals that the entire nested strategy should be deleted; when `false` / omitted, this argument signals that the target step should be removed, but all the other nested strategy slots should be kept intact.

**Future work:** Which working on this issue, I noticed that we sometimes offer "delete" for steps whose removal would produce an invalid step tree. ([Example.](https://plasmodb.org/plasmo/app/workspace/strategies/import/04a656b7269bed86)) I'm guessing the logic for deriving the `isDeleteable` `StepBox` prop is too permissive.

![image](https://user-images.githubusercontent.com/15959217/115073660-a7270e80-9ec6-11eb-9a9f-83c753c4922d.png)

