### PR TITLE
Prepopulate the step analysis form state using the validated params p…

### DIFF
--- a/Client/src/Core/MoveAfterRefactor/StoreModules/StepAnalysis/StepAnalysisObservers.ts
+++ b/Client/src/Core/MoveAfterRefactor/StoreModules/StepAnalysis/StepAnalysisObservers.ts
@@ -61,7 +61,7 @@ import {
 
 import { transitionToInternalPage } from 'wdk-client/Actions/RouterActions';
 import { StepAnalysisType } from 'wdk-client/Utils/StepAnalysisUtils';
-import { InvalidStepValidation } from 'wdk-client/Utils/WdkUser';
+import { InvalidStepValidation, extractParamValues } from 'wdk-client/Utils/WdkUser';
 
 export const observeStartLoadingTabListing = (action$: ActionsObservable<Action>, state$: StateObservable<StepAnalysesState>, { wdkService }: EpicDependencies) => {
   return action$.pipe(
@@ -187,13 +187,7 @@ export const observeStartLoadingChosenAnalysisTab = (action$: ActionsObservable<
             analysisType: choice,
             pollCountdown: 0,
             paramSpecs,
-            paramValues: paramSpecs.reduce(
-              (memo, { name, initialDisplayValue }) => ({
-                ...memo,
-                [name]: initialDisplayValue || ''
-              }),
-              {}
-            ),
+            paramValues: extractParamValues(paramSpecs),
             panelUiState: {
               descriptionExpanded: false,
               formExpanded: true

--- a/Client/src/Service/Mixins/StepAnalysisService.ts
+++ b/Client/src/Service/Mixins/StepAnalysisService.ts
@@ -3,6 +3,7 @@ import * as Decode from 'wdk-client/Utils/Json';
 import { stepAnalysisDecoder, stepAnalysisConfigDecoder, stepAnalysisTypeDecoder, stepAnalysisStatusDecoder, FormParams, StepAnalysisType, StepAnalysisConfig } from 'wdk-client/Utils/StepAnalysisUtils';
 import { parametersDecoder } from 'wdk-client/Service/Mixins/SearchesService';
 import { Parameter, ParameterValues } from 'wdk-client/Utils/WdkModel';
+import { extractParamValues } from 'wdk-client/Utils/WdkUser';
 
 export type StepAnalysisWithParameters = StepAnalysisType & {
   parameters: Parameter[];
@@ -100,6 +101,7 @@ export default (base: ServiceBase) => {
         stepId, stepAnalysisConfig.analysisName, stepAnalysisConfig.parameters)
       .then(displayParams => ({
         ...stepAnalysisConfig,
+        parameters: extractParamValues(displayParams),
         displayParams
       }));
     })

--- a/Client/src/StoreModules/QuestionStoreModule.ts
+++ b/Client/src/StoreModules/QuestionStoreModule.ts
@@ -60,7 +60,7 @@ import {
   fulfillCreateStrategy
 } from 'wdk-client/Actions/StrategyActions';
 import { addStep } from 'wdk-client/Utils/StrategyUtils';
-import {Step} from 'wdk-client/Utils/WdkUser';
+import { Step, extractParamValues } from 'wdk-client/Utils/WdkUser';
 import { transitionToInternalPage } from 'wdk-client/Actions/RouterActions';
 import { InferAction, mergeMapRequestActionsToEpic as mrate } from 'wdk-client/Utils/ActionCreatorUtils';
 import { ParamValueStore } from 'wdk-client/Utils/ParamValueStore';
@@ -788,8 +788,8 @@ async function loadQuestion(
 
     const recordClass = await wdkService.findRecordClass(question.outputRecordClassName);
 
-    const defaultParamValues = extractParamValues(defaultQuestion, {}, step);
-    const paramValues = extractParamValues(question, initialParams, step);
+    const defaultParamValues = extractParamValues(defaultQuestion.parameters, {}, step);
+    const paramValues = extractParamValues(question.parameters, initialParams, step);
 
     const wdkWeight = step == null ? undefined : step.searchConfig.wdkWeight;
 
@@ -846,20 +846,6 @@ function initialParamDataWithDatasetParamSpecialCase(initialParamData: Parameter
   return Object.keys(initialParamData).reduce(function(result, paramName) {
     return paramName.indexOf(".idList") > -1 ? result : Object.assign(result, {[paramName] : initialParamData[paramName]});
   }, {});
-}
-
-function extractParamValues(question: QuestionWithParameters, initialParams: ParameterValues,  step?: Step ){
-  return question.parameters.reduce(function(values, { name, initialDisplayValue, type }) {
-    return Object.assign(values, {
-      [name]: (
-        (step == null && type === 'input-step')
-        ? ''
-        : (name in initialParams)
-          ? initialParams[name]
-          : initialDisplayValue
-      )
-    });
-  }, {} as ParameterValues);
 }
 
 function updateLastParamValues(

--- a/Client/src/Utils/WdkUser.ts
+++ b/Client/src/Utils/WdkUser.ts
@@ -8,7 +8,11 @@ import {
   record,
   string,
 } from 'wdk-client/Utils/Json';
-import { AnswerSpec } from 'wdk-client/Utils/WdkModel';
+import {
+  AnswerSpec,
+  Parameter,
+  ParameterValues
+} from 'wdk-client/Utils/WdkModel';
 import { Omit } from 'wdk-client/Core/CommonTypes';
 
 export interface User {
@@ -270,3 +274,17 @@ export interface UserCommentGetResponse {
 export interface UserCommentPostResponse  {id: number};
 
 export interface UserCommentAttachedFilePostResponse  {id: number};
+
+export function extractParamValues(parameters: Parameter[], initialParams: ParameterValues = {}, step?: Step){
+  return parameters.reduce(function(values, { name, initialDisplayValue, type }) {
+    return Object.assign(values, {
+      [name]: (
+        (step == null && type === 'input-step')
+        ? ''
+        : (name in initialParams)
+          ? initialParams[name]
+          : initialDisplayValue
+      )
+    });
+  }, {} as ParameterValues);
+}


### PR DESCRIPTION
…rovided in the response for POST /steps/:step-id/analyses/analysis-types/:analysisTypeName

This PR fixes the following bug:

1. On a genomics site, open a search with an organism param
2. Select a single organism, call it `A`
3. Run the search
4. Add and run a pathway enrichment analysis on the new step
5. Revise the step by unselecting organism `A` and selecting a different organism `B`
6. Resubmit the analysis form
7. The client will issue a `PATCH` using the old (and now invalid) organism `A`

The issue is that, when loading an analysis, we’re initializing the `paramValues` Redux state with the old, potentially invalid, values returned by the `GET` to `/steps/:stepId/analyses/:analysisId`. The fix is to initialize the `paramValues` Redux state with the new, validated values returned by the subsequent `POST` to `/steps/:stepId/analysis-types/:analysisTypeName`.