### PR TITLE
Power the RecordSidebar's sticky container using "position: sticky"

### DIFF
--- a/Client/src/Views/Records/Record.css
+++ b/Client/src/Views/Records/Record.css
@@ -43,6 +43,11 @@
   min-height: 65vh;
 }
 
+.wdk-RecordSidebarContainer {
+  position: sticky;
+  top: 0;
+}
+
 .wdk-RecordSidebar {
   left: -332px;
   width: 282px;
@@ -54,12 +59,6 @@
   padding: 0 8px;
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.3);
   border: 1px solid #ccc;
-}
-
-.wdk-RecordSidebar__fixed {
-  position: fixed;
-  top: 0;
-  left: -312px;
 }
 
 .wdk-RecordSidebarHeader {
@@ -90,10 +89,6 @@
 
 .wdk-RecordContainer__withSidebar .wdk-RecordSidebar {
   left: 0;
-}
-
-.wdk-RecordContainer__withSidebar .wdk-RecordSidebar__fixed {
-  left: 20px;
 }
 
 .wdk-RecordContainer__withSidebar .wdk-RecordSidebarToggle {

--- a/Client/src/Views/Records/RecordUI.jsx
+++ b/Client/src/Views/Records/RecordUI.jsx
@@ -2,7 +2,6 @@ import classnames from 'classnames';
 import { debounce, get } from 'lodash';
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
-import Sticky from 'wdk-client/Components/Display/Sticky';
 import { getId } from 'wdk-client/Utils/CategoryUtils';
 import { wrappable } from 'wdk-client/Utils/ComponentUtils';
 import { addScrollAnchor } from 'wdk-client/Utils/DomUtils';
@@ -105,39 +104,36 @@ class RecordUI extends Component {
           recordClass={this.props.recordClass}
           headerActions={this.props.headerActions}
         />
-        <Sticky>
-          {({isFixed}) => (
-            <div className={'wdk-RecordSidebar' + (
-              isFixed ? ' wdk-RecordSidebar__fixed' : '')}>
-              <button type="button" className="wdk-RecordSidebarToggle"
-                onClick={() => {
-                  if (!this.props.navigationVisible) window.scrollTo(0, window.scrollY);
-                  this.props.updateNavigationVisibility(!this.props.navigationVisible);
-                }}
-              >
-                {this.props.navigationVisible ? '' : 'Show Contents '}
-                <i className={sidebarIconClass}
-                  title={this.props.navigationVisible ? 'Close sidebar' : 'Open sidebar'}/>
-              </button>
-              <RecordNavigationSection
-                heading={this.props.record.displayName}
-                record={this.props.record}
-                recordClass={this.props.recordClass}
-                categoryTree={this.props.categoryTree}
-                collapsedSections={this.props.collapsedSections}
-                activeSection={this.props.activeSection}
-                navigationQuery={this.props.navigationQuery}
-                navigationExpanded={this.props.navigationExpanded}
-                navigationCategoriesExpanded={this.props.navigationCategoriesExpanded}
-                onSectionToggle={this.props.updateSectionVisibility}
-                onNavigationVisibilityChange={this.props.updateNavigationVisibility}
-                onNavigationCategoryExpansionChange={this.props.updateNavigationCategoryExpansion}
-                onNavigationQueryChange={this.props.updateNavigationQuery}
-                requestPartialRecord={this.props.requestPartialRecord}
-              />
-            </div>
-          )}
-        </Sticky>
+        <div className="wdk-RecordSidebarContainer">
+          <div className="wdk-RecordSidebar">
+            <button type="button" className="wdk-RecordSidebarToggle"
+              onClick={() => {
+                if (!this.props.navigationVisible) window.scrollTo(0, window.scrollY);
+                this.props.updateNavigationVisibility(!this.props.navigationVisible);
+              }}
+            >
+              {this.props.navigationVisible ? '' : 'Show Contents '}
+              <i className={sidebarIconClass}
+                title={this.props.navigationVisible ? 'Close sidebar' : 'Open sidebar'}/>
+            </button>
+            <RecordNavigationSection
+              heading={this.props.record.displayName}
+              record={this.props.record}
+              recordClass={this.props.recordClass}
+              categoryTree={this.props.categoryTree}
+              collapsedSections={this.props.collapsedSections}
+              activeSection={this.props.activeSection}
+              navigationQuery={this.props.navigationQuery}
+              navigationExpanded={this.props.navigationExpanded}
+              navigationCategoriesExpanded={this.props.navigationCategoriesExpanded}
+              onSectionToggle={this.props.updateSectionVisibility}
+              onNavigationVisibilityChange={this.props.updateNavigationVisibility}
+              onNavigationCategoryExpansionChange={this.props.updateNavigationCategoryExpansion}
+              onNavigationQueryChange={this.props.updateNavigationQuery}
+              requestPartialRecord={this.props.requestPartialRecord}
+            />
+          </div>
+        </div>
         <div className="wdk-RecordMain">
           {/* <div className="wdk-RecordMainSectionFieldToggles">
             <button type="button" title="Expand all content" className="wdk-Link"


### PR DESCRIPTION
This PR refactors the `RecordSidebar`'s sticky container to use `position: sticky`.

(Motivation: there is [a Redmine](https://redmine.apidb.org/issues/44483) regarding the new org prefs header blocking the RecordSidebar's header. To fix this, I want to override the position of the sticky container, which is a little easier to do with `position: sticky`.)