### PR TITLE
Make SearchInputSelector wrappable

### DIFF
--- a/Client/src/Components.ts
+++ b/Client/src/Components.ts
@@ -71,6 +71,7 @@ import ResultPanelHeader from 'wdk-client/Views/Strategy/ResultPanelHeader';
 import AnswerTableCell from 'wdk-client/Views/Answer/AnswerTableCell';
 import SliderInput from 'wdk-client/Components/InputControls/SliderInput';
 import UnhandledErrors from 'wdk-client/Views/UnhandledErrors/UnhandledErrors';
+import { SearchInputSelector } from 'wdk-client/Views/Strategy/SearchInputSelector';
 
 export {
   AccordionButton,
@@ -131,6 +132,7 @@ export {
   ResultTabs,
   ReporterSortMessage,
   SaveableTextEditor,
+  SearchInputSelector,
   ServerSideAttributeFilter,
   SingleSelect,
   SliderInput,

--- a/Client/src/Views/Strategy/SearchInputSelector.tsx
+++ b/Client/src/Views/Strategy/SearchInputSelector.tsx
@@ -12,7 +12,7 @@ import { DispatchAction } from 'wdk-client/Core/CommonTypes';
 import { RootState } from 'wdk-client/Core/State/Types';
 import { getDisplayName, getTargetType, getRecordClassUrlSegment, CategoryTreeNode, getTooltipContent, getAllBranchIds, getRecordClassName, EMPTY_CATEGORY_TREE_NODE, isQualifying, CategoryOntology } from 'wdk-client/Utils/CategoryUtils';
 
-import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+import { makeClassNameHelper, wrappable } from 'wdk-client/Utils/ComponentUtils';
 import { pruneDescendantNodes, getLeaves, mapStructure } from 'wdk-client/Utils/TreeUtils';
 import { StrategyDetails } from 'wdk-client/Utils/WdkUser';
 import { RecordClass } from 'wdk-client/Utils/WdkModel';
@@ -44,7 +44,7 @@ type OwnProps = {
   selectBasketButtonText: string
 };
 
-type Props = StateProps & DispatchProps & OwnProps;
+export type Props = StateProps & DispatchProps & OwnProps;
 
 const cx = makeClassNameHelper('SearchInputSelector');
 
@@ -344,4 +344,9 @@ const mapDispatchToProps = (dispatch: DispatchAction) => ({
   requestBasketCounts: compose(dispatch, requestBasketCounts)
 });
 
-export const SearchInputSelector = connect(mapStateToProps, mapDispatchToProps)(SearchInputSelectorView);
+const enhance = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
+export const SearchInputSelector = enhance(wrappable(SearchInputSelectorView));


### PR DESCRIPTION
Use case: for Add Step on genomics sites, we want to restrict tree of available searches based on the user's preferred organisms.