### PR TITLE
Configurable Navigation Items

### DIFF
--- a/Client/src/Components.ts
+++ b/Client/src/Components.ts
@@ -71,6 +71,7 @@ import ResultPanelHeader from 'wdk-client/Views/Strategy/ResultPanelHeader';
 import AnswerTableCell from 'wdk-client/Views/Answer/AnswerTableCell';
 import SliderInput from 'wdk-client/Components/InputControls/SliderInput';
 import UnhandledErrors from 'wdk-client/Views/UnhandledErrors/UnhandledErrors';
+import RecordNavigationSection from 'wdk-client/Views/Records/RecordNavigation/RecordNavigationSection';
 
 export {
   AccordionButton,
@@ -123,6 +124,7 @@ export {
   RecordHeading,
   RecordLink,
   RecordMainSection,
+  RecordNavigationSection,
   RecordTable,
   RecordTableDescription,
   RecordTableSection,

--- a/Client/src/Views/Records/RecordNavigation/RecordNavigationSection.jsx
+++ b/Client/src/Views/Records/RecordNavigation/RecordNavigationSection.jsx
@@ -68,7 +68,8 @@ class RecordNavigationSection extends React.PureComponent {
       navigationQuery,
       navigationCategoriesExpanded,
       onNavigationCategoryExpansionChange,
-      onSectionToggle
+      onSectionToggle,
+      visibilityFilter = isNotAttribute
     } = this.props;
 
     return (
@@ -78,7 +79,7 @@ class RecordNavigationSection extends React.PureComponent {
         </h2>
         <CategoriesCheckboxTree
           disableHelp
-          visibilityFilter={isNotAttribute}
+          visibilityFilter={visibilityFilter}
           searchBoxPlaceholder="Search section names..."
           tree={categoryTree}
           leafType="section"

--- a/Client/src/Views/Records/RecordUtils.ts
+++ b/Client/src/Views/Records/RecordUtils.ts
@@ -62,10 +62,10 @@ export function getSearchableString(filterAttributes: string[], filterTables: st
 // Category tree interactions
 // --------------------------
 
-const isInternalNode = partial(nodeHasProperty, 'scope', 'record-internal');
+export const isInternalNode = partial(nodeHasProperty, 'scope', 'record-internal');
 export const isNotInternalNode = partial(nodeHasProperty, 'scope', 'record');
-const isAttributeNode = partial(nodeHasProperty, 'targetType', 'attribute');
-const isTableNode = partial(nodeHasProperty, 'targetType', 'table');
+export const isAttributeNode = partial(nodeHasProperty, 'targetType', 'attribute');
+export const isTableNode = partial(nodeHasProperty, 'targetType', 'table');
 const getAttributes = partial(filterNodes, isAttributeNode);
 const getTables = partial(filterNodes, isTableNode);
 const getNodeName = partial(getPropertyValue, 'name');


### PR DESCRIPTION
This PR allows the `RecordNavigationSection`'s visibility filter to be overridden via a prop.

Use Case: ClinEpi wants to display attributes AND tables in their `RecordNavigationSection`.

@dmfalke I'll be self-merging this since @aurreco-uga wanted to exhibit this work as part of the upcoming ClinEpi UX demo, and I know you're busy with EDA stuff. Please feel free to do a "post-merge review!"