### PR TITLE
Workspace navigation: support replace and scrollToTop behavior

### DIFF
--- a/Client/src/Components/Workspace/WorkspaceNavigation.tsx
+++ b/Client/src/Components/Workspace/WorkspaceNavigation.tsx
@@ -4,11 +4,10 @@ import { NavLink, NavLinkProps } from "react-router-dom";
 
 import './WorkspaceNavigation.scss';
 
-interface WorkspaceNavigationItem {
+interface WorkspaceNavigationItem extends Pick<NavLinkProps, 'isActive' | 'replace'> {
   display: ReactNode;
   route: string;
   state?: any;
-  isActive?: NavLinkProps['isActive'];
   exact?: boolean;
 }
 
@@ -32,6 +31,7 @@ export default function WorkspaceNavigation(props: Props) {
           activeClassName={cx('--Item', 'active')}
           isActive={item.isActive}
           exact={item.exact ?? true}
+          replace={item.replace}
           to={{
             pathname: routeBase + item.route,
             state: item.state

--- a/Client/src/Components/Workspace/WorkspaceNavigation.tsx
+++ b/Client/src/Components/Workspace/WorkspaceNavigation.tsx
@@ -34,7 +34,7 @@ export default function WorkspaceNavigation(props: Props) {
           replace={item.replace}
           to={{
             pathname: routeBase + item.route,
-            state: item.state
+            state: { scrollToTop: false, ...item.state }
           }}
         >
           {item.display}

--- a/Client/src/Hooks/Page.ts
+++ b/Client/src/Hooks/Page.ts
@@ -1,30 +1,34 @@
-import { Action, History, Location } from 'history';
+import { Action } from 'history';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 
+export interface LocationState {
+  scrollToTop?: boolean;
+}
+
 export function useScrollUpOnRouteChange() {
-  const location: Location = useLocation();
-  const history: History = useHistory();
+  const location = useLocation<LocationState | undefined>();
+  const history = useHistory<LocationState | undefined>();
 
   const [ prevPathname, setPrevPathname ] = useState(location.pathname);
   const [ prevQueryString, setPrevQueryString ] = useState(location.search);
 
   useEffect(() => {
-    const removeHistoryListener = history.listen((newLocation: Location, action: Action) => {
-      if (
-        action !== 'REPLACE' &&
-        !navigatingWithinStrategyWorkspace(prevPathname, newLocation.pathname) &&
-        !newLocation.hash &&
-        (
-          prevPathname !== newLocation.pathname ||
-          prevQueryString !== newLocation.search
-        )
-      ) {
-        window.scrollTo(0, 0);
-      }
-
+    const removeHistoryListener = history.listen((newLocation, action) => {
       setPrevPathname(newLocation.pathname);
       setPrevQueryString(newLocation.search);
+
+      if (
+        newLocation.state?.scrollToTop === false ||
+        action === 'REPLACE' ||
+        navigatingWithinStrategyWorkspace(prevPathname, newLocation.pathname) ||
+        newLocation.hash || (
+          prevPathname === newLocation.pathname &&
+          prevQueryString === newLocation.search
+        )
+      ) return;
+
+      window.scrollTo(0, 0);
     });
 
     return removeHistoryListener;

--- a/Client/src/Hooks/Page.ts
+++ b/Client/src/Hooks/Page.ts
@@ -1,4 +1,3 @@
-import { Action } from 'history';
 import { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 
@@ -21,7 +20,6 @@ export function useScrollUpOnRouteChange() {
       if (
         newLocation.state?.scrollToTop === false ||
         action === 'REPLACE' ||
-        navigatingWithinStrategyWorkspace(prevPathname, newLocation.pathname) ||
         newLocation.hash || (
           prevPathname === newLocation.pathname &&
           prevQueryString === newLocation.search
@@ -33,11 +31,4 @@ export function useScrollUpOnRouteChange() {
 
     return removeHistoryListener;
   } , []);
-}
-
-function navigatingWithinStrategyWorkspace(prevPathname: string, newPathname: string) {
-  return (
-    prevPathname.startsWith('/workspace/strategies') &&
-    newPathname.startsWith('/workspace/strategies')
-  );
 }


### PR DESCRIPTION
This PR improves the `WorkspaceNavigation` component in the following ways:
1. Consumers can specify that a "tab" will replace the current location.
2. "Tabs" will set the `scrollToTop` flag to `false` to prevent the page from jumping when switching tabs.