### PR TITLE
Update natural-sort datatables plugin to handle html content as expected

### DIFF
--- a/Client/vendored/datatables-natural-type-plugin.js
+++ b/Client/vendored/datatables-natural-type-plugin.js
@@ -48,7 +48,7 @@ function naturalSort (a, b, html) {
 		x = a.toString().replace(sre, '') || '',
 		y = b.toString().replace(sre, '') || '';
 		// remove html from strings if desired
-		if (!html) {
+		if (html) {
 			x = x.replace(htmre, '');
 			y = y.replace(htmre, '');
 		}


### PR DESCRIPTION
The semantics of the `html` flag seem the opposite of what is expected. This PR flips the logic.