### PR TITLE
Use callback for Task.fromPromise

### DIFF
--- a/Client/src/Utils/Task.ts
+++ b/Client/src/Utils/Task.ts
@@ -21,9 +21,9 @@ export class Task<T, E> {
     return new Task<T, E>((fulfill, reject) => void reject(e));
   }
 
-  static fromPromise<T, E>(p: Promise<T>) {
+  static fromPromise<T, E>(callback: () => Promise<T>) {
     return new Task<T, E>(function(fulfill, reject) {
-      p.then(fulfill, reject);
+      callback().then(fulfill, reject);
     });
   }
 

--- a/Client/src/Utils/__tests__/TaskTest.ts
+++ b/Client/src/Utils/__tests__/TaskTest.ts
@@ -52,11 +52,11 @@ describe('Task', () => {
   });
 
   test('Task.fromPromise should create a Task from a Promise', t => {
-    let cancel = Task.fromPromise(Promise.resolve(1))
+    let cancel = Task.fromPromise(() => Promise.resolve(1))
       .run(() => void t.fail('this should cancel'));
     cancel();
 
-    Task.fromPromise(Promise.resolve(10))
+    Task.fromPromise(() => Promise.resolve(10))
       .run(v => expect(v).toBe(10));
 
     setTimeout(() => t(), 1000);


### PR DESCRIPTION
A `Task`'s underlying process should not be executed until the `.run` method is called. This PR ensures that contract by having `Task.fromPromise` take a callback function.