### PR TITLE
Mesa and Answer Table Performance Improvements

### DIFF
--- a/Client/src/Components/Mesa/Ui/DataTable.jsx
+++ b/Client/src/Components/Mesa/Ui/DataTable.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { isEqual } from 'lodash';
+import { createSelector, defaultMemoize } from 'reselect';
+
 import HeadingRow from 'wdk-client/Components/Mesa/Ui/HeadingRow';
 import DataRowList from 'wdk-client/Components/Mesa/Ui/DataRowList';
 import { makeClassifier, combineWidths } from 'wdk-client/Components/Mesa/Utils/Utils';
@@ -133,7 +136,7 @@ class DataTable extends React.Component {
     const { dynamicWidths, tableWrapperWidth } = this.state;
     const newColumns = columns.every(({ width }) => width) || !dynamicWidths || dynamicWidths.length == 0
       ? columns
-      : columns.map((column, index) => Object.assign({}, column, { width: dynamicWidths[index] }));
+      : makeColumnsWithDynamicWidths({ columns, dynamicWidths });
     const bodyWrapperStyle = { maxHeight: options ? options.tableBodyMaxHeight : null };
     const wrapperStyle = { minWidth: dynamicWidths ? combineWidths(columns.map(({ width }) => width)) : null };
     const headerWrapperStyle = { width: tableWrapperWidth, display: dynamicWidths == null ? 'none' : 'block' };
@@ -208,5 +211,15 @@ DataTable.propTypes = {
   uiState: PropTypes.object,
   eventHandlers: PropTypes.objectOf(PropTypes.func)
 };
+
+const makeColumnsWithDynamicWidths = defaultMemoize(
+  ({ columns, dynamicWidths }) => columns.map(
+    (column, index) => Object.assign({}, column, { width: dynamicWidths[index] })
+  ),
+  (a, b) => (
+    a.columns === b.columns &&
+    isEqual(a.dynamicWidths, b.dynamicWidths)
+  )
+);
 
 export default DataTable;

--- a/Client/src/Components/Mesa/Ui/DataTable.jsx
+++ b/Client/src/Components/Mesa/Ui/DataTable.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { isEqual } from 'lodash';
-import { createSelector, defaultMemoize } from 'reselect';
+import { defaultMemoize } from 'reselect';
 
 import HeadingRow from 'wdk-client/Components/Mesa/Ui/HeadingRow';
 import DataRowList from 'wdk-client/Components/Mesa/Ui/DataRowList';

--- a/Client/src/Controllers/AnswerController.tsx
+++ b/Client/src/Controllers/AnswerController.tsx
@@ -1,10 +1,9 @@
-import { isEqual } from 'lodash';
 import QueryString from 'querystring';
 import * as React from 'react';
 import PageController from 'wdk-client/Core/Controllers/PageController';
 import { RootState } from 'wdk-client/Core/State/Types';
 import { wrappable } from 'wdk-client/Utils/ComponentUtils';
-import { isEmpty, ListIteratee } from 'lodash';
+import { isEmpty, isEqual, ListIteratee } from 'lodash';
 import {
   loadAnswer,
   changeColumnPosition,
@@ -20,8 +19,11 @@ import { connect } from 'react-redux';
 import { AttributeField, TableField, AttributeValue, RecordInstance, RecordClass } from 'wdk-client/Utils/WdkModel';
 import { History } from 'history';
 import { filterRecords } from 'wdk-client/Views/Records/RecordUtils';
+import { defaultMemoize } from 'reselect';
 
 const MAXROWS = 2000;
+
+const PAGE_SIZE = 100;
 
 const ActionCreators = {
   loadAnswer,
@@ -73,6 +75,7 @@ type OwnProps = {
   filterTerm?: string;
   filterAttributes?: string[];
   filterTables?: string[];
+  offset?: number;
   history: History;
 }
 
@@ -107,6 +110,24 @@ class AnswerController extends PageController<Props> {
     if (!isEmpty(filterTables)) queryParams.filterTables = filterTables;
     const queryString = QueryString.stringify(queryParams);
     this.props.ownProps.history.replace(`?${queryString}`);
+  }
+
+  changeOffset = (offset: number) => {
+    const { history } = this.props.ownProps;
+    const currentParams = QueryString.parse(history.location.search.slice(1));
+
+    // remove current offset query param
+    delete currentParams.offset;
+
+    if (!offset) {
+      const queryString = QueryString.stringify(currentParams);
+      history.replace(`?${queryString}`);
+      return;
+    }
+
+    const queryParams = { ...currentParams, offset };
+    const queryString = QueryString.stringify(queryParams);
+    history.replace(`?${queryString}`);
   }
 
   loadData(prevProps?: Props) {
@@ -213,6 +234,7 @@ class AnswerController extends PageController<Props> {
       filterTerm,
       filterAttributes = [],
       filterTables = [],
+      offset = 0
     } = this.props.ownProps;
 
     const {
@@ -221,12 +243,22 @@ class AnswerController extends PageController<Props> {
       changeVisibleColumns
     } = this.props.dispatchProps;
 
-    const filteredRecords = records && filterTerm ? filterRecords(records, { filterTerm, filterAttributes, filterTables }) : records;
+    const pageSize = PAGE_SIZE;
+
+    const filteredRecords = records && filterTerm
+      ? makeFilteredRecords({ records, filterTerm, filterAttributes, filterTables })
+      : records;
+
+    const totalRows = filteredRecords?.length;
+    const totalPages = totalRows != null && Math.ceil(totalRows / pageSize);
+
+    const filteredRecordsPage = makeFilteredRecordsPage({ filteredRecords, offset, pageSize });
+    const currentPageTotalRows = filteredRecordsPage != null && filteredRecordsPage.length;
 
     return (
       <CastAnswer
         meta={meta}
-        records={filteredRecords}
+        records={filteredRecordsPage}
         question={question}
         recordClass={recordClass}
         displayInfo={displayInfo}
@@ -235,8 +267,14 @@ class AnswerController extends PageController<Props> {
         filterTerm={filterTerm}
         filterAttributes={filterAttributes}
         filterTables={filterTables}
+        offset={offset}
+        currentPageTotalRows={currentPageTotalRows}
+        totalRows={totalRows}
+        totalPages={totalPages}
+        pageSize={pageSize}
         format="table"
         onSort={changeSorting}
+        onOffsetChange={this.changeOffset}
         onMoveColumn={changeColumnPosition}
         onChangeColumns={changeVisibleColumns}
         onFilter={this.changeFilter}
@@ -258,6 +296,35 @@ class AnswerController extends PageController<Props> {
   }
 
 }
+
+const shallowCompare = (a: any, b: any) =>
+  Object.keys(a).every(aKey => a[aKey] === b[aKey]) ||
+  Object.keys(b).every(bKey => a[bKey] === b[bKey]);
+
+const makeFilteredRecords = defaultMemoize(
+  (
+    {
+      records,
+      filterTerm,
+      filterAttributes,
+      filterTables
+    }: Pick<Required<Props['stateProps']>, 'records' | 'filterTerm' | 'filterAttributes' | 'filterTables'>
+  ) =>
+    filterRecords(records, { filterTerm, filterAttributes, filterTables }),
+  shallowCompare
+);
+
+const makeFilteredRecordsPage = defaultMemoize(
+  (
+    {
+      filteredRecords,
+      offset,
+      pageSize
+    }: { filteredRecords?: RecordInstance[], offset: number, pageSize: number }
+  ) =>
+    filteredRecords?.slice(offset, offset + pageSize),
+  shallowCompare
+);
 
 const mapStateToProps = (state: RootState) => state.answerView;
 

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -42,7 +42,8 @@ const routes: RouteEntry[] = [
   {
     path: '/search/:recordClass/:question/result',
     component: (props: RouteComponentProps<{recordClass: string; question: string;}>) => {
-      const { filterTerm, filterAttributes = [], filterTables = [] } = QueryString.parse(props.location.search.slice(1));
+      const { filterTerm, filterAttributes = [], filterTables = [], offset = '0' } = QueryString.parse(props.location.search.slice(1));
+      const offsetStr = isArray(offset) ? offset[0] : offset;
       const parameters = parseSearchParamsFromQueryParams(parseQueryString(props));
       return (
         <AnswerController
@@ -51,6 +52,7 @@ const routes: RouteEntry[] = [
           filterTerm={isArray(filterTerm) ? filterTerm[0] : filterTerm}
           filterAttributes={castArray(filterAttributes)}
           filterTables={castArray(filterTables)}
+          offset={Math.max(parseInt(offsetStr, 10), 0)}
           history={props.history}
         />
       )

--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -32,7 +32,7 @@ function Answer(props) {
         (totalPages - 1) * pageSize
       ));
     }
-  }, [offset, pageSize, totalRows, onOffsetChange]);
+  }, [offset, pageSize, totalRows, totalPages, onOffsetChange]);
 
   const onPageChange = useCallback(newPage => {
     onOffsetChange((newPage - 1) * pageSize);


### PR DESCRIPTION
This PR improves performance of the Answer table by:

* Introducing client-side pagination to the Answer component
* Speeding up certain rerenders of `Mesa`'s underlying `DataTable` component (by memoizing the derivation of the "columns with dynamic widths")

Avenues for future work:
* Allow Mesa consumers to specify a stabler row key than `rowIndex`.
* Eliminate some/all rerenders of sticky `DataTable`s which occur when their `dynamicWidths` state changes. @dmfalke suggests only passing the dynamic widths to the header of the table.
* Explore other React table libraries.