### PR TITLE
Mesa sticky header performance improvement

### DIFF
--- a/Client/src/Components/Mesa/Ui/DataTable.jsx
+++ b/Client/src/Components/Mesa/Ui/DataTable.jsx
@@ -46,7 +46,6 @@ class DataTable extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
-      this.props.rows !== prevProps.rows ||
       this.props.columns.map(c => c.name).toString() !== prevProps.columns.map(c => c.name).toString()
     ) {
       this.setDynamicWidths();

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -42,8 +42,7 @@ const routes: RouteEntry[] = [
   {
     path: '/search/:recordClass/:question/result',
     component: (props: RouteComponentProps<{recordClass: string; question: string;}>) => {
-      const { filterTerm, filterAttributes = [], filterTables = [], offset = '0' } = QueryString.parse(props.location.search.slice(1));
-      const offsetStr = isArray(offset) ? offset[0] : offset;
+      const { filterTerm, filterAttributes = [], filterTables = [] } = QueryString.parse(props.location.search.slice(1));
       const parameters = parseSearchParamsFromQueryParams(parseQueryString(props));
       return (
         <AnswerController
@@ -52,7 +51,6 @@ const routes: RouteEntry[] = [
           filterTerm={isArray(filterTerm) ? filterTerm[0] : filterTerm}
           filterAttributes={castArray(filterAttributes)}
           filterTables={castArray(filterTables)}
-          offset={Math.max(parseInt(offsetStr, 10), 0)}
           history={props.history}
         />
       )

--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -1,8 +1,8 @@
 import { orderBy, uniq } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { withRouter } from 'react-router';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
-import { Mesa, MesaState, PaginationMenu } from 'wdk-client/Components/Mesa';
+import { Mesa, MesaState } from 'wdk-client/Components/Mesa';
 import Dialog from 'wdk-client/Components/Overlays/Dialog';
 import { wrappable } from 'wdk-client/Utils/ComponentUtils';
 import AttributeSelector from 'wdk-client/Views/Answer/AnswerAttributeSelector';
@@ -11,32 +11,9 @@ import AnswerTableCell from 'wdk-client/Views/Answer/AnswerTableCell';
 import 'wdk-client/Views/Answer/wdk-Answer.scss';
 
 function Answer(props) {
-  const {
-    question,
-    recordClass,
-    displayInfo,
-    additionalActions,
-    offset,
-    totalRows,
-    totalPages,
-    onOffsetChange,
-    pageSize,
-  } = props;
+  const { question, recordClass, displayInfo, additionalActions } = props;
 
   const tableState = useTableState(props);
-
-  useEffect(() => {
-    if (offset >= totalRows) {
-      onOffsetChange(Math.max(
-        0,
-        (totalPages - 1) * pageSize
-      ));
-    }
-  }, [offset, pageSize, totalRows, onOffsetChange]);
-
-  const onPageChange = useCallback(newPage => {
-    onOffsetChange((newPage - 1) * pageSize);
-  }, [offset, onOffsetChange, pageSize]);
 
   return (
     <div className="wdk-AnswerContainer">
@@ -47,18 +24,9 @@ function Answer(props) {
         {recordClass.description}
       </div>
       <div className="wdk-Answer">
-        <div style={{ display: 'flex', alignItems: 'center', minHeight: '4.75em' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
           <AnswerFilter {...props}/>
           <AnswerCount {...props} />
-          <div className="MesaComponent">
-            <PaginationMenu
-              totalRows={totalRows}
-              totalPages={totalPages}
-              currentPage={Math.ceil((offset + 1) / pageSize)}
-              rowsPerPage={pageSize}
-              onPageChange={onPageChange}
-            />
-          </div>
           <div style={{ flex: 1, textAlign: 'right' }}>
             {additionalActions?.map(({ key, display }) =>
               <React.Fragment key={key}>
@@ -75,11 +43,14 @@ function Answer(props) {
 }
 
 function AnswerCount(props) {
-  const { recordClass, records, totalRows, offset, currentPageTotalRows } = props;
+  const { recordClass, meta, records, displayInfo } = props;
   const { displayNamePlural } = recordClass;
+  const { pagination } = displayInfo;
+  const { offset, numRecords } = pagination;
+  const { totalCount, responseCount } = meta;
   const first = offset + 1;
-  const last = offset + currentPageTotalRows;
-  const countPhrase = !records.length ? 0 : `${first} - ${last} of ${totalRows}`;
+  const last = Math.min(offset + numRecords, responseCount, records.length);
+  const countPhrase = !records.length ? 0 : `${first} - ${last} of ${totalCount}`;
 
   return (
     <p className="wdk-Answer-count">

--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -32,7 +32,7 @@ function Answer(props) {
         (totalPages - 1) * pageSize
       ));
     }
-  }, [offset, pageSize, totalRows, totalPages, onOffsetChange]);
+  }, [offset, pageSize, totalRows, onOffsetChange]);
 
   const onPageChange = useCallback(newPage => {
     onOffsetChange((newPage - 1) * pageSize);


### PR DESCRIPTION
This PR:

* Reverts pagination for the Answer table
* Alters the circumstances where Mesa `DataTable` sticky column widths are recalculated: now instead of recomputing these widths whenever (1) the rows change OR (2) the name and order of the columns changes, we only recompute them in the case of (2). Consequently, sorting or filtering a Mesa table with a sticky header now only triggers one rerender (instead of three).