### PR TITLE
Client Plugins: introduce optional "fallback" prop

### DIFF
--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -103,6 +103,7 @@ function QuestionController(props: Props) {
           recordClassName
         }}
         pluginProps={props}
+        fallback={<Loading />}
       />
     ),
     [ searchName, recordClassName ] 

--- a/Client/src/Controllers/ResultPanelController.tsx
+++ b/Client/src/Controllers/ResultPanelController.tsx
@@ -6,6 +6,7 @@ import { memoize, isEqual } from 'lodash/fp';
 import ResultTabs, { TabConfig } from 'wdk-client/Core/MoveAfterRefactor/Components/Shared/ResultTabs';
 import { connect } from 'react-redux';
 import { transitionToInternalPage } from 'wdk-client/Actions/RouterActions';
+import { Loading } from 'wdk-client/Components';
 import { RootState } from 'wdk-client/Core/State/Types';
 import {
   analysisPanelOrder,
@@ -266,6 +267,7 @@ const mergeProps = (
               resultType: ownProps.resultType,
               viewId: ownProps.viewId
             }}
+            fallback={<Loading />}
           />
         ) : null
       })
@@ -298,6 +300,7 @@ const mergeProps = (
               renameAnalysis: eventHandlers.renameAnalysis(+baseTabConfig.key),
               duplicateAnalysis: eventHandlers.duplicateAnalysis(+baseTabConfig.key)
             }}
+            fallback={<Loading />}
           />
         )
       })

--- a/Client/src/Core/routes.tsx
+++ b/Client/src/Core/routes.tsx
@@ -28,7 +28,7 @@ import QuestionController from 'wdk-client/Controllers/QuestionController';
 import { Plugin } from 'wdk-client/Utils/ClientPlugin';
 import StrategyWorkspaceController from 'wdk-client/Controllers/StrategyWorkspaceController';
 import BasketController from 'wdk-client/Controllers/BasketController';
-import { PermissionDenied } from 'wdk-client/Components';
+import { Loading, PermissionDenied } from 'wdk-client/Components';
 import NotFound from 'wdk-client/Views/NotFound/NotFound';
 import Error from 'wdk-client/Components/PageStatus/Error';
 import UserDatasetsWorkspace from 'wdk-client/Views/UserDatasets/UserDatasetsWorkspace';
@@ -86,6 +86,7 @@ const routes: RouteEntry[] = [
             prepopulateWithLastParamValues: true
           }}
           defaultComponent={QuestionController}
+          fallback={<Loading />}
         />
       );
     }

--- a/Client/src/Utils/ClientPlugin.tsx
+++ b/Client/src/Utils/ClientPlugin.tsx
@@ -31,6 +31,7 @@ type CompositePluginComponentProps<PluginProps> = {
   context: PluginEntryContext;
   pluginProps: PluginProps;
   defaultComponent?: PluginComponent<PluginProps>;
+  fallback?: React.ReactNode;
 }
 
 type ResolvedPluginReferences = {
@@ -107,7 +108,7 @@ function makeCompositePluginComponentUncached<T>(registry: ClientPluginRegistryE
       }
     }, [ props.context.paramName, props.context.searchName, props.context.recordClassName ]);
 
-    if (resolvedReferences == null) return null;
+    if (resolvedReferences == null) return <>{props.fallback}</> ?? null;
 
     if ('error' in resolvedReferences) {
       return resolvedReferences.error.status === 404

--- a/Client/src/Views/Strategy/CombineStepForm.tsx
+++ b/Client/src/Views/Strategy/CombineStepForm.tsx
@@ -122,6 +122,7 @@ const CombineStepFormView = ({
                 addType
               }
             }}
+            fallback={<Loading />}
           />  
         </div>
       </div>;

--- a/Client/src/Views/Strategy/ConvertStepForm.tsx
+++ b/Client/src/Views/Strategy/ConvertStepForm.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
+import { Loading } from 'wdk-client/Components';
+import { Plugin } from 'wdk-client/Utils/ClientPlugin';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { AddStepOperationFormProps } from 'wdk-client/Views/Strategy/AddStepPanel';
 
 import 'wdk-client/Views/Strategy/ConvertStepForm.scss';
-import {Plugin} from 'wdk-client/Utils/ClientPlugin';
 
 const cx = makeClassNameHelper('ConvertStepForm');
 
@@ -48,6 +49,7 @@ export const ConvertStepForm = ({
               addType
             }
           }}
+          fallback={<Loading />}
         />
       </div>
     </div>

--- a/Client/src/Views/Strategy/StrategyPanel.tsx
+++ b/Client/src/Views/Strategy/StrategyPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SaveableTextEditor, Loading } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+import { QuestionController } from 'wdk-client/Controllers';
 import { StrategyDetails } from 'wdk-client/Utils/WdkUser';
 import { AddStepPanel } from 'wdk-client/Views/Strategy/AddStepPanel';
 import { AddType, PartialUiStepTree } from 'wdk-client/Views/Strategy/Types';
@@ -139,9 +140,11 @@ export default function StrategyPanel(props: Props) {
                   strategyId: strategy.strategyId,
                   stepId: reviseStep.id,
                   previousSearchConfig: reviseStep.searchConfig
-                },
+                } as const,
                 submitButtonText: 'Revise'
               }}
+              defaultComponent={QuestionController}
+              fallback={<Loading />}
             />
           </div>
         </StrategyModal>


### PR DESCRIPTION
This PR introduces an optional `fallback` prop for client plugins. It is intended to improve loading UX for `Plugin`-based pages/views for which "plugin reference resolution" is delayed.

In addition, fallback are provided for several `Plugin`-based pages/views:
* Search pages
* Question forms in the Add Step and Revise Step modals
* Summary views
* Step analysis views