### PR TITLE
Add ability to override subsetting distribution bar colors

### DIFF
--- a/Client/src/Components/AttributeFilter/MembershipField.jsx
+++ b/Client/src/Components/AttributeFilter/MembershipField.jsx
@@ -490,6 +490,8 @@ class MembershipTable extends React.PureComponent {
         count={row.count}
         filteredCount={row.filteredCount}
         populationSize={this.props.activeFieldState.summary.internalsCount || this.props.dataCount}
+        fillBarColor={this.props.fillBarColor}
+        fillFilteredBarColor={this.props.fillFilteredBarColor}
       />
     );
   }

--- a/Client/src/Components/AttributeFilter/StackedBar.jsx
+++ b/Client/src/Components/AttributeFilter/StackedBar.jsx
@@ -2,13 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 export default function StackedBar(props) {
+  // Set bar colors
+  const fillBarColor = props.fillBarColor || "#aaaaaa";
+  const fillFilteredBarColor = props.fillFilteredBarColor || "#DA7272";
+
   return (
     <div className="bar">
       <div className="fill" style={{
-        width: (props.count / props.populationSize * 100) + '%'
+        width: (props.count / props.populationSize * 100) + '%',
+        backgroundColor: fillBarColor
       }}/>
       <div className="fill filtered" style={{
-        width: (props.filteredCount / props.populationSize * 100) + '%'
+        width: (props.filteredCount / props.populationSize * 100) + '%',
+        backgroundColor: fillFilteredBarColor
       }}/>
     </div>
   );

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
@@ -451,13 +451,9 @@
 }
 .filter-param .bar .fill {
   color: white;
-  background-color: #aaaaaa;
   height: 1em;
   position: absolute;
   min-width: 1px;
-}
-.filter-param .fill.filtered {
-  background-color: #DA7272;
 }
 .filter-param .filter-param-legend {
   float: right;


### PR DESCRIPTION
*Depends on web-eda [PR #377](https://github.com/VEuPathDB/web-eda/pull/377)*

Addresses web-eda [issue #301](https://github.com/VEuPathDB/web-eda/issues/301)

The goal of this PR is to allow the bar colors in the subsetting step to be optionally defined elsewhere and passed as props. The default values match the current colors on the live site (defined in FilterParam.css, class `.fill.filtered` and `.bar .fill`).

The current PR functions as intended, but I struggled with making the decision about where to define the default colors. Currently this is done in the StackedBar component but other options include within MembershipField or MembershipTable. Is it better to define such a default at the highest or lowest level? 


