### PR TITLE
multifilter pass colors to stackedbar

### DIFF
--- a/Client/src/Components/AttributeFilter/MultiFieldFilter.jsx
+++ b/Client/src/Components/AttributeFilter/MultiFieldFilter.jsx
@@ -174,6 +174,8 @@ export default class MultiFieldFilter extends React.Component {
             count={getCount(row.summary, row.value)}
             filteredCount={getFilteredCount(row.summary, row.value)}
             populationSize={row.summary.internalsCount || this.props.dataCount}
+            fillBarColor={this.props.fillBarColor}
+            fillFilteredBarColor={this.props.fillFilteredBarColor}
           />
         </div>
       )


### PR DESCRIPTION
With web-eda [PR #408](https://github.com/VEuPathDB/web-eda/pull/408) , allows predefined colors to be passed to the stacked bars in the distribution column of the data table in the subsetting tab, for multifilter variables.

Previous PR #151 updated the above for numeric and categorical variables, but not for multifilter. The same implementation strategy as in PR #151 is implemented here. See also web-eda [issue #301](https://github.com/VEuPathDB/web-eda/issues/301) for more details