### PR TITLE
New "onLogin" client config

### DIFF
--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -23,6 +23,8 @@ import defaultPluginConfig from 'wdk-client/Core/pluginConfig';
 import storeModules from 'wdk-client/StoreModules';
 import { createWdkStore } from 'wdk-client/Core/Store';
 
+export const GUEST_USER_ID_KEY = 'login::guestUserId';
+
 /**
  * Initialize the application.
  *

--- a/Client/src/StoreModules/UserSessionStoreModule.ts
+++ b/Client/src/StoreModules/UserSessionStoreModule.ts
@@ -60,7 +60,11 @@ function observeShowLoginForm(
     filter(showLoginForm.isOfType),
     mergeMap(async action => {
       const { destination = window.location.href } = action.payload;
-      const config = await wdkService.getConfig();
+      const [config, { id: guestUserId }] = await Promise.all([
+        wdkService.getConfig(),
+        wdkService.getCurrentUser()
+      ]);
+      sessionStorage.setItem('login::guestUserId', `${guestUserId}`);
       let { oauthClientId, oauthClientUrl, oauthUrl, method } = config.authentication;
       if (method === 'OAUTH2') {
         return performOAuthLogin(destination, wdkService, oauthClientId, oauthClientUrl, oauthUrl);

--- a/Client/src/StoreModules/UserSessionStoreModule.ts
+++ b/Client/src/StoreModules/UserSessionStoreModule.ts
@@ -20,6 +20,7 @@ import {
 } from 'wdk-client/Actions/UserSessionActions';
 import { WdkService } from 'wdk-client/Core';
 import { RootState } from 'wdk-client/Core/State/Types';
+import { GUEST_USER_ID_KEY } from 'wdk-client/Core/main';
 
 export const key = 'userSession';
 
@@ -64,7 +65,7 @@ function observeShowLoginForm(
         wdkService.getConfig(),
         wdkService.getCurrentUser()
       ]);
-      sessionStorage.setItem('login::guestUserId', `${guestUserId}`);
+      sessionStorage.setItem(GUEST_USER_ID_KEY, `${guestUserId}`);
       let { oauthClientId, oauthClientUrl, oauthUrl, method } = config.authentication;
       if (method === 'OAUTH2') {
         return performOAuthLogin(destination, wdkService, oauthClientId, oauthClientUrl, oauthUrl);


### PR DESCRIPTION
Motivated by https://github.com/VEuPathDB/web-eda/issues/490.

**Future work:** 
1. Instead of persisting the guest user id in session storage, maybe it could be included as a cookie in the "successful login" response?
2. Address a potential vector for race conditions: currently, the redux static data is being loaded before `onLogin` is run. If `onLogin` alters the backend source of this static data, the redux representation will be stale. The naive solution is to not execute `loadAllStaticData` until the `onLogin` Task has fulfilled or rejected, but this could result in performance issues (e.g., due to delayed loading of the ontology).