### PR TITLE
adding prefix at table heading and centered

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -114,5 +114,9 @@
     "reporters": [
       "jest-tap-reporter"
     ]
+  },
+  "volta": {
+    "node": "14.15.5",
+    "yarn": "1.22.10"
   }
 }

--- a/Client/src/Components/AttributeFilter/MembershipField.jsx
+++ b/Client/src/Components/AttributeFilter/MembershipField.jsx
@@ -126,6 +126,7 @@ class MembershipField extends React.PureComponent {
 
 MembershipField.defaultProps = {
   filteredCountHeadingPrefix: 'Remaining',
+  unfilteredCountHeadingPrefix: '',
 }
 
 function filterBySearchTerm(rows, searchTerm){
@@ -223,7 +224,7 @@ class MembershipTable extends React.PureComponent {
     return get(this.props, 'filter.value');
   }
 
-   
+
 
   deriveRowClassName(item) {
     const selectedClassName = (
@@ -371,7 +372,7 @@ class MembershipTable extends React.PureComponent {
       .every(member => this.isItemSelected(member));
     const someAvailableChecked = availableItems
       .some(member => this.isItemSelected(member));
-    
+
     const showChecked = availableItems.length > 0 && allAvailableChecked;
     const showIndeterminate = availableItems.length > 0 && someAvailableChecked && ! allAvailableChecked;
 
@@ -430,7 +431,7 @@ class MembershipTable extends React.PureComponent {
 
   renderCountHeading1(qualifier) {
     return (
-      <div style={{display: 'flex', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+      <div style={{display: 'flex', justifyContent: 'center', flexWrap: 'wrap' }}>
         <div>{qualifier}</div>
         <div style={{marginLeft: '.6ex', maxWidth: '6em', overflow: 'hidden', textOverflow: 'ellipsis'}}>{this.props.displayName}</div>
       </div>
@@ -473,7 +474,7 @@ class MembershipTable extends React.PureComponent {
   }
 
   renderUnfilteredCountHeading1() {
-    return this.renderCountHeading1('');
+    return this.renderCountHeading1(this.props.unfilteredCountHeadingPrefix);
   }
 
   renderUnfilteredCountHeading2() {
@@ -528,8 +529,8 @@ class MembershipTable extends React.PureComponent {
       useSearch && searchTerm
       ? {searchTerm}
       : {},
-      usePagination 
-      ? { 
+      usePagination
+      ? {
         pagination:  {
           currentPage,
           rowsPerPage,
@@ -540,7 +541,7 @@ class MembershipTable extends React.PureComponent {
       }
       : {}
     );
-      
+
     const eventHandlers = Object.assign(
       {
         // onRowSelect: this.handleRowSelect,


### PR DESCRIPTION
This addresses: a) adding volta at package.json; b) add prefix to table heading; c) center alignment for table heading
Following link has screenshots: https://github.com/VEuPathDB/web-eda/issues/418#issuecomment-940517973. 

If this change is accepted by Danica, then I will make this be regular PR.

I noticed that Dave manually makes version up for this WDKClient repo, so it would be necessary to check the version so that it would be upgraded at [corresponding web-eda PR](https://github.com/VEuPathDB/web-eda/pull/551).
