### PR TITLE
change css for centering table heading

### DIFF
--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
@@ -324,7 +324,7 @@
 .filter-param .membership-filter .MesaComponent th:nth-child(3) .HeadingCell-Content-Label,
 .filter-param .membership-filter .MesaComponent th:nth-child(4) .HeadingCell-Content-Label {
   margin-left: auto;
-  text-align: right;
+  text-align: center;
 }
 /* Numeric columns (All and Matching) */
 .filter-param .membership-filter .MesaComponent .HeadingRow:last-child th:nth-child(3),


### PR DESCRIPTION
I have changed the CSS as there was exceptions reported by Bob. @dmfalke it would be great if you can add another version up then I will update web-eda too.

- before change (Bob's screenshot)
![137039531-575a4c3c-6df6-46a8-a059-60b30ab30b01](https://user-images.githubusercontent.com/12802305/137051884-7a204c78-c9c3-4662-8dc0-84f42a840bc4.png)


- After the change it looks like this
![table-heading-centering](https://user-images.githubusercontent.com/12802305/137051798-9ab8b62e-8a38-45e8-9895-2ad5b7a65752.png)

