### PR TITLE
Introduce wrapWdkDependencies

### DIFF
--- a/Client/src/Core/CommonTypes.ts
+++ b/Client/src/Core/CommonTypes.ts
@@ -1,6 +1,9 @@
 import { Action } from 'redux';
 
-import { ActionCreatorResult } from 'wdk-client/Core/WdkMiddleware';
+import {
+  ActionCreatorResult,
+  ActionCreatorServices
+} from 'wdk-client/Core/WdkMiddleware';
 import { UserDataset } from 'wdk-client/Utils/WdkModel';
 
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
@@ -10,8 +13,8 @@ export interface SimpleDispatch {
   (action: Action): void;
 }
 
-export interface DispatchAction {
-  (action: ActionCreatorResult<Action>): any;
+export interface DispatchAction<S extends ActionCreatorServices = ActionCreatorServices> {
+  (action: ActionCreatorResult<Action, S>): any;
 }
 
 export interface MesaColumn<K extends string = string> {

--- a/Client/src/Core/Root.tsx
+++ b/Client/src/Core/Root.tsx
@@ -14,7 +14,7 @@ import { RouteEntry } from 'wdk-client/Core/RouteEntry';
 import WdkRoute from 'wdk-client/Core/WdkRoute';
 import { safeHtml } from 'wdk-client/Utils/ComponentUtils';
 import UnhandledErrorsController from 'wdk-client/Controllers/UnhandledErrorsController';
-import { WdkDependencies, WdkDepdendenciesContext } from 'wdk-client/Hooks/WdkDependenciesEffect';
+import { WdkDependencies, WdkDependenciesContext } from 'wdk-client/Hooks/WdkDependenciesEffect';
 
 type Props = {
   rootUrl: string,
@@ -106,7 +106,7 @@ export default class Root extends React.Component<Props, State> {
       <Provider store={this.props.store}>
         <ErrorBoundary>
           <Router history={this.props.history}>
-            <WdkDepdendenciesContext.Provider value={this.props.wdkDependencies}>
+            <WdkDependenciesContext.Provider value={this.props.wdkDependencies}>
               <PluginContext.Provider value={makeCompositePluginComponent(this.props.pluginConfig)}>
                 <Page classNameModifier={rootClassNameModifier}>
                   {staticContent ? safeHtml(staticContent, null, 'div') : (
@@ -129,7 +129,7 @@ export default class Root extends React.Component<Props, State> {
                   )}
                 </Page>
               </PluginContext.Provider>
-            </WdkDepdendenciesContext.Provider>
+            </WdkDependenciesContext.Provider>
           </Router>
         </ErrorBoundary>
       </Provider>

--- a/Client/src/Core/Store.ts
+++ b/Client/src/Core/Store.ts
@@ -35,15 +35,15 @@ type StoreModuleRecord<T extends Record<string, any>, A extends Action> = {
 
 type RootReducer<T, A extends Action> = Reducer<T, A>;
 
-export function createWdkStore<T, A extends Action>(
+export function createWdkStore<T, A extends Action, E extends EpicDependencies>(
   storeModules: StoreModuleRecord<T, A>,
-  dependencies: EpicDependencies,
+  dependencies: E,
   // FIXME Figure out how to allow the order of middleware to be configured
   additionalMiddleware: Middleware[] = []
 ) {
   const rootReducer = makeRootReducer(storeModules);
   const rootEpic = makeRootEpic(storeModules);
-  const epicMiddleware = createEpicMiddleware<A, A, T, EpicDependencies>({
+  const epicMiddleware = createEpicMiddleware<A, A, T, E>({
     dependencies
   });
 

--- a/Client/src/Core/Store.ts
+++ b/Client/src/Core/Store.ts
@@ -35,7 +35,7 @@ type StoreModuleRecord<T extends Record<string, any>, A extends Action> = {
 
 type RootReducer<T, A extends Action> = Reducer<T, A>;
 
-export function createWdkStore<T, A extends Action, E extends EpicDependencies>(
+export function createWdkStore<T, A extends Action, E extends EpicDependencies = EpicDependencies>(
   storeModules: StoreModuleRecord<T, A>,
   dependencies: E,
   // FIXME Figure out how to allow the order of middleware to be configured

--- a/Client/src/Core/WdkMiddleware.ts
+++ b/Client/src/Core/WdkMiddleware.ts
@@ -1,14 +1,10 @@
 import { Middleware } from 'redux';
 import { isPromise } from 'wdk-client/Utils/PromiseUtils';
 import { Action } from 'wdk-client/Actions';
-import { PageTransitioner } from 'wdk-client/Utils/PageTransitioner';
-import WdkService from 'wdk-client/Service/WdkService';
 import { notifyUnhandledError } from 'wdk-client/Actions/UnhandledErrorActions';
+import { EpicDependencies } from 'wdk-client/Core/Store';
 
-export interface ActionCreatorServices {
-  wdkService: WdkService;
-  transitioner: PageTransitioner;
-}
+export type ActionCreatorServices = EpicDependencies;
 
 export type ActionCreatorResult<T> =
   | T
@@ -70,7 +66,7 @@ type WdkMiddleWare = Middleware<DispatchAction<Action>>;
  * rejections to go unhandled, which made comprehensive error handling more
  * difficult.
  */
-export const wdkMiddleware = (services: ActionCreatorServices): WdkMiddleWare => ({ dispatch }) => next => action => {
+export const wdkMiddleware = <T extends ActionCreatorServices>(services: T): WdkMiddleWare => ({ dispatch }) => next => action => {
   try {
     if (typeof action === 'function') {
       return dispatch(action(services));

--- a/Client/src/Core/main.js
+++ b/Client/src/Core/main.js
@@ -41,7 +41,9 @@ import { createWdkStore } from 'wdk-client/Core/Store';
  *   and returns a modified copy.
  * @param {Function} [options.wrapStoreModules] A function that takes WDK StoreModules
  *   and returns a modified copy.
- * @param {Function} [options.wrapWdkService] A functino that takes WdkService
+ * @param {Function} [options.wrapWdkDependencies] A function that takes WdkDependencies
+ *   and returns a modified copy.
+  * @param {Function} [options.wrapWdkService] A function that takes a WdkService
  *   class and returns a sub class.
  * @param {Function} [options.onLocationChange] Callback function called whenever
  *   the location of the page changes. The function is called with a Location
@@ -57,6 +59,7 @@ export function initialize(options) {
     retainContainerContent = false,
     wrapRoutes = identity,
     wrapStoreModules = identity,
+    wrapWdkDependencies = identity,
     wrapWdkService = identity,
     onLocationChange,
     pluginConfig = [],
@@ -75,11 +78,11 @@ export function initialize(options) {
   let paramValueStore = getParamValueStoreInstance(endpoint, wdkService);
   let transitioner = getTransitioner(history);
 
-  let wdkDependencies = {
+  let wdkDependencies = wrapWdkDependencies({
     paramValueStore,
     transitioner,
     wdkService
-  };
+  });
 
   let store = createWdkStore(
     wrapStoreModules(storeModules),

--- a/Client/src/Hooks/NonNullableContext.ts
+++ b/Client/src/Hooks/NonNullableContext.ts
@@ -1,17 +1,17 @@
-import { useContext, Context } from 'react';
+import { makeUseRefinedContext } from 'wdk-client/Hooks/RefinedContext';
+
+const isNonNullable = <T>(t: T): t is NonNullable<T> => t != null;
 
 /**
- * Ensures the value of React Context has been initialize and is not null.
+ * Ensures the value of React Context has been initialized and is not null.
  * This is useful to prevent a consumer from accessing context before it is
  * initialized with a value. 
  */
-export function useNonNullableContext<T>(context: Context<T>): NonNullable<T> {
-  const v = useContext(context);
-  if (v == null)
-    throw new Error(
-      'Context has not be initialized: ' +
-        (context.displayName ?? 'unknown') +
-        ' context.'
-    );
-  return v as NonNullable<T>;
-}
+export const useNonNullableContext = makeUseRefinedContext(
+  isNonNullable,
+  context => (
+    'Context has not been initialized: ' +
+    (context.displayName ?? 'unknown') +
+    ' context.'
+  )
+);

--- a/Client/src/Hooks/RefinedContext.ts
+++ b/Client/src/Hooks/RefinedContext.ts
@@ -12,7 +12,7 @@ export function makeUseRefinedContext<T, U extends T>(
   return function useRefinedContext(context: Context<T>): U {
     const v = useContext(context);
 
-    if (!(isRefinedValue(v))) {
+    if (!isRefinedValue(v)) {
       throw new Error(makeMissingContextError(context));
     }
 

--- a/Client/src/Hooks/RefinedContext.ts
+++ b/Client/src/Hooks/RefinedContext.ts
@@ -3,7 +3,7 @@ import { Context, useContext } from 'react';
 /**
  * Ensures the value of React Context is of a specified subtype.
  * This is useful to prevent a consumer from accessing context which
- * has not been properply configured.
+ * has not been properly configured.
  */
 export function makeUseRefinedContext<T, U extends T>(
   isRefinedValue: (v: T) => v is U,

--- a/Client/src/Hooks/RefinedContext.ts
+++ b/Client/src/Hooks/RefinedContext.ts
@@ -1,0 +1,21 @@
+import { Context, useContext } from 'react';
+
+/**
+ * Ensures the value of React Context is of a specified subtype.
+ * This is useful to prevent a consumer from accessing context which
+ * has not been properply configured.
+ */
+export function makeUseRefinedContext<T, U extends T>(
+  isRefinedValue: (v: T) => v is U,
+  makeMissingContextError: (context: Context<T>) => string
+) {
+  return function useRefinedContext(context: Context<T>): U {
+    const v = useContext(context);
+
+    if (!(isRefinedValue(v))) {
+      throw new Error(makeMissingContextError(context));
+    }
+
+    return v;
+  }
+}

--- a/Client/src/Hooks/WdkDependenciesEffect.ts
+++ b/Client/src/Hooks/WdkDependenciesEffect.ts
@@ -9,12 +9,15 @@ export type DepEffectCallback<T> = ((dep: T) => void) | ((dep: T) => void | unde
 
 // FIXME Figure out a way to make the context type WdkDependencies (as opposed to WdkDependencies | undefined)
 // FIXME One approach would be to create the context in main.js
-export const WdkDepdendenciesContext = React.createContext<WdkDependencies | undefined>(undefined);
+export const WdkDependenciesContext = React.createContext<WdkDependencies | undefined>(undefined);
+
+// FIXME Remove once all existing "WdkDepdendenciesContext" typos have been fixed
+export const WdkDepdendenciesContext = WdkDependenciesContext;
 
 export type WdkDependenciesEffectCallback = DepEffectCallback<WdkDependencies>;
 
 export const useWdkDependenciesEffect = (effect: WdkDependenciesEffectCallback, deps?: DependencyList): void => {
-  const wdkDependencies = useContext(WdkDepdendenciesContext);
+  const wdkDependencies = useContext(WdkDependenciesContext);
 
   useEffect(() => {
     if (wdkDependencies == null) {


### PR DESCRIPTION
This PR introduces a `wrapWdkDependencies` config, which can be used to provide additional services to the various consumers of `WdkDependencies`:

1. Component and hooks (via `WdkDependenciesContext`)
2. Redux middleware (passed as an argument to WDK epics and thunks)

A utility hook "factory" is also introduced to facilitate working with wrapped React context.