### PR TITLE
Default sort by study when sortingAttribute is null

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -148,8 +148,6 @@ function useTableState (props) {
 
   const rows = useMemo(() => {
     const sortingAttribute = visibleAttributes.find(attribute => attribute.name === sorting[0].attributeName)
-    console.log({ sortingAttribute })
-    console.log({ visibleAttributes })
     const sortKeys = makeSortKeys(sortingAttribute ? sortingAttribute : visibleAttributes[0].name, customSortBys);
     const sortDirections = sortKeys.map(_ => sorting[0].direction.toLowerCase() || 'asc');
 

--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -147,8 +147,10 @@ function useTableState (props) {
   );
 
   const rows = useMemo(() => {
-    const sortingAttribute = visibleAttributes.find( attribute => attribute.name === sorting[0].attributeName )
-    const sortKeys = makeSortKeys(sortingAttribute, customSortBys);
+    const sortingAttribute = visibleAttributes.find(attribute => attribute.name === sorting[0].attributeName)
+    console.log({ sortingAttribute })
+    console.log({ visibleAttributes })
+    const sortKeys = makeSortKeys(sortingAttribute ? sortingAttribute : visibleAttributes[0].name, customSortBys);
     const sortDirections = sortKeys.map(_ => sorting[0].direction.toLowerCase() || 'asc');
 
     return orderBy(records, sortKeys, sortDirections);


### PR DESCRIPTION
Addresses [this issue](https://github.com/VEuPathDB/EdaNewIssues/issues/214) wherein removing the column that the summary table is sorted by results in a `TypeError` because `sortingAttribute` is null.

I added a ternary that will pass the first column's name attribute in place of `sortingAttribute` in the event that `sortingAttribute` is null. The first column, study name, is non-removable and thus a safe default.

I tested this small change in both a Plasmo and ClinEpi dev site. Both are exhibiting the desired result.