### PR TITLE
Fix results table bug when rows per page are increased

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -172,6 +172,11 @@ function getEventHandlers(props: Props) {
   }
   function onRowsPerPageChange(newRowsPerPage: number) {
     requestPageSizeUpdate(newRowsPerPage);
+    // NOTE: When this condition is met, ensure viewPageNumber is invoked after invoking requestPageSizeUpdate
+    if (Math.ceil(answer.meta.totalCount / newRowsPerPage) < Math.ceil((answer.meta.pagination.offset + 1) / answer.meta.pagination.numRecords)) {
+      // Sets the page to the last available page when setting newRowsPerPage results in the currentPage no longer existing
+      viewPageNumber(Math.ceil(answer.meta.totalCount/newRowsPerPage));
+    }
   }
   function onRowSelect(row: RecordInstance) {
     onMultipleRowSelect([row]);

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -171,11 +171,10 @@ function getEventHandlers(props: Props) {
     viewPageNumber(newPage);
   }
   function onRowsPerPageChange(newRowsPerPage: number) {
-    // NOTE: To avoid an error, invoke requestPageSizeUpdate before invoking viewPageNumber
     requestPageSizeUpdate(newRowsPerPage);
-    /* 
-      Calculates which page to set every time "Rows per page" is changed. Specifically, it sets 
-      the page such that the top row's data is included on the new page's render. This ensures that
+    /*
+      Calculates which page to set every time "Rows per page" is changed such that 
+      the top row's data is included on the new page's render. This ensures that
       the user is in close proximity to whatever data they were previously viewing.
     */
     viewPageNumber(Math.ceil((answer.meta.pagination.offset + 1) / newRowsPerPage));

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -171,12 +171,14 @@ function getEventHandlers(props: Props) {
     viewPageNumber(newPage);
   }
   function onRowsPerPageChange(newRowsPerPage: number) {
+    // NOTE: To avoid an error, invoke requestPageSizeUpdate before invoking viewPageNumber
     requestPageSizeUpdate(newRowsPerPage);
-    // NOTE: When this condition is met, ensure viewPageNumber is invoked after invoking requestPageSizeUpdate
-    if (Math.ceil(answer.meta.totalCount / newRowsPerPage) < Math.ceil((answer.meta.pagination.offset + 1) / answer.meta.pagination.numRecords)) {
-      // Sets the page to the last available page when setting newRowsPerPage results in the currentPage no longer existing
-      viewPageNumber(Math.ceil(answer.meta.totalCount/newRowsPerPage));
-    }
+    /* 
+      Calculates which page to set every time "Rows per page" is changed. Specifically, it sets 
+      the page such that the top row's data is included on the new page's render. This ensures that
+      the user is in close proximity to whatever data they were previously viewing.
+    */
+    viewPageNumber(Math.ceil((answer.meta.pagination.offset + 1) / newRowsPerPage));
   }
   function onRowSelect(row: RecordInstance) {
     onMultipleRowSelect([row]);


### PR DESCRIPTION
Addresses [this issue](https://trello.com/c/SEN8NY19/1652-results-table-bug-with-paging).

The bug happens when a user changes the "rows per column" such that the `currentPage` would no longer exists. For example, if a user is on page 10 of a study with 500 records set to show 20 rows per column, selecting 100 rows per column would result in only 5 total pages and thus throw an error (since page 10 no longer exists).

I added a check in the `onRowsPerChange` handler that sets the `currentPage` to the last available page in the event this happens.