### PR TITLE
Search pages: disable form submission while dependent params are updating

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Relates to https://github.com/VEuPathDB/web-multi-blast/issues/10. That issue is likely arising because users can submit 
a "new job" form while its advanced parameters are being refreshed. In MultiBLAST, such submission errors are not immediately caught, because the WDK doesn't (and likely can't) validate "new job" form submissions.