### PR TITLE
Assign object instead of property to fix bug in column sorting

### DIFF
--- a/Client/src/Views/Answer/Answer.jsx
+++ b/Client/src/Views/Answer/Answer.jsx
@@ -148,7 +148,7 @@ function useTableState (props) {
 
   const rows = useMemo(() => {
     const sortingAttribute = visibleAttributes.find(attribute => attribute.name === sorting[0].attributeName)
-    const sortKeys = makeSortKeys(sortingAttribute ? sortingAttribute : visibleAttributes[0].name, customSortBys);
+    const sortKeys = makeSortKeys(sortingAttribute ? sortingAttribute : visibleAttributes[0], customSortBys);
     const sortDirections = sortKeys.map(_ => sorting[0].direction.toLowerCase() || 'asc');
     return orderBy(records, sortKeys, sortDirections);
   }, [records, sorting, visibleAttributes, customSortBys]);


### PR DESCRIPTION
Addresses issue #202.

Fixes the error in which a property of an object, instead of the expected object itself, was passed into the function `makeSortKeys`.