### PR TITLE
Accommodate Gene List UD exports

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -98,32 +98,25 @@ export default (base: ServiceBase) => {
       reportConfig: reportConfig
     };
 
-    const temporaryResult$ = typeof answerSpecOrStepId === 'number'
-      ? await base.sendRequest<{ id: string }>(
-          record({ id: string }),
-          {
-            method: 'post',
-            path: '/temporary-results',
-            body: stringify({
-              ...reportSubrequest,
-              stepId: answerSpecOrStepId,
-            })
-          }
-        )
-      : await base.sendRequest<{ id: string }>(
-          record({ id: string }),
-          {
-            method: 'post',
-            path: '/temporary-results',
-            body: stringify({
-              ...reportSubrequest,
-              searchName: answerSpecOrStepId.searchName,
-              searchConfig: answerSpecOrStepId.searchConfig,
-            })
-          }
-        );
+    const requestBody = typeof answerSpecOrStepId === 'number'
+      ? stringify({
+          ...reportSubrequest,
+          stepId: answerSpecOrStepId,
+        })
+      : stringify({
+          ...reportSubrequest,
+          searchName: answerSpecOrStepId.searchName,
+          searchConfig: answerSpecOrStepId.searchConfig,
+        });
 
-    const { id } = await temporaryResult$;
+    const { id } = await base.sendRequest<{ id: string }>(
+      record({ id: string }),
+      {
+        method: 'post',
+        path: '/temporary-results',
+        body: requestBody
+      }
+    );
 
     return '/temporary-results/' + id;
   }

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -91,7 +91,7 @@ export default (base: ServiceBase) => {
   async function getTemporaryResultPath(
     answerSpecOrStepId: AnswerSpec | number,
     reportName: string,
-    reportConfig: StandardReportConfig
+    reportConfig: unknown
   ) {
     const reportSubrequest = {
       reportName: reportName,

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -89,23 +89,42 @@ export default (base: ServiceBase) => {
   }
 
   async function getTemporaryResultPath(
-    answerSpec: AnswerSpec,
+    answerSpecOrStepId: AnswerSpec | number,
     reportName: string,
     reportConfig: StandardReportConfig
   ) {
-    const { id } = await base.sendRequest<{ id: string }>(
-      record({ id: string }),
-      {
-        method: 'post',
-        path: '/temporary-results',
-        body: stringify({
-          searchName: answerSpec.searchName,
-          searchConfig: answerSpec.searchConfig,
-          reportName: reportName,
-          reportConfig: reportConfig
-        })
-      }
-    );
+    const reportSubrequest = {
+      reportName: reportName,
+      reportConfig: reportConfig
+    };
+
+    const temporaryResult$ = typeof answerSpecOrStepId === 'number'
+      ? await base.sendRequest<{ id: string }>(
+          record({ id: string }),
+          {
+            method: 'post',
+            path: '/temporary-results',
+            body: stringify({
+              ...reportSubrequest,
+              stepId: answerSpecOrStepId,
+            })
+          }
+        )
+      : await base.sendRequest<{ id: string }>(
+          record({ id: string }),
+          {
+            method: 'post',
+            path: '/temporary-results',
+            body: stringify({
+              ...reportSubrequest,
+              searchName: answerSpecOrStepId.searchName,
+              searchConfig: answerSpecOrStepId.searchConfig,
+            })
+          }
+        );
+
+    const { id } = await temporaryResult$;
+
     return '/temporary-results/' + id;
   }
 

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -43,10 +43,10 @@ export interface Props {
   closeAttributeAnalysis: CloseAttributeAnalysis;
   updateSelectedIds: UpdateSelectedIds;
   showLoginWarning: ShowLoginWarning;
-  renderTableActions?: (props: TableActionsProps) => React.ReactNode;
+  renderToolbarContent?: (props: ToolbarContentProps) => React.ReactNode;
 }
 
-export interface TableActionsProps {
+export interface ToolbarContentProps {
   addColumnsNode: React.ReactNode;
   addToBasketNode: React.ReactNode;
   downloadLinkNode: React.ReactNode;
@@ -63,7 +63,7 @@ function ResultTable(props: Props) {
     selectedIds,
     userIsGuest,
     showLoginWarning,
-    renderTableActions = defaultRenderTableActions
+    renderToolbarContent = defaultRenderToolbarContent,
   } = props;
   const columns = getColumns(props);
   const rows = answer.records;
@@ -140,7 +140,7 @@ function ResultTable(props: Props) {
 
   return (
     <Mesa state={tableState}>
-      {renderTableActions({
+      {renderToolbarContent({
         addColumnsNode,
         addToBasketNode,
         downloadLinkNode
@@ -314,7 +314,7 @@ function getColumns({
   return recordClass.useBasket ? [basketColumn, ...answerColumns] : answerColumns;
 }
 
-function defaultRenderTableActions(props: TableActionsProps) {
+function defaultRenderToolbarContent(props: ToolbarContentProps) {
   return (
     <>
       {props.downloadLinkNode}

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -43,6 +43,13 @@ export interface Props {
   closeAttributeAnalysis: CloseAttributeAnalysis;
   updateSelectedIds: UpdateSelectedIds;
   showLoginWarning: ShowLoginWarning;
+  renderTableActions?: (props: TableActionsProps) => React.ReactNode;
+}
+
+export interface TableActionsProps {
+  addColumnsNode: React.ReactNode;
+  addToBasketNode: React.ReactNode;
+  downloadLinkNode: React.ReactNode;
 }
 
 function ResultTable(props: Props) {
@@ -55,7 +62,8 @@ function ResultTable(props: Props) {
     actions,
     selectedIds,
     userIsGuest,
-    showLoginWarning
+    showLoginWarning,
+    renderTableActions = defaultRenderTableActions
   } = props;
   const columns = getColumns(props);
   const rows = answer.records;
@@ -95,17 +103,21 @@ function ResultTable(props: Props) {
   const downloadLink = resultType.type === 'step' ? `/step/${resultType.step.id}/download`
     : resultType.type === 'basket' ? `/workspace/basket/${resultType.basketName}/download`
     : undefined;
-  return (
-    <Mesa state={tableState}>
-      {downloadLink &&
-        <div className="ResultTableButton">
+
+  const downloadLinkNode = (
+    downloadLink == null
+      ? null
+      : <div className="ResultTableButton">
           <Link className="btn" to={downloadLink}>
             <IconAlt fa="download"/> Download
           </Link>
         </div>
-      }
-      {!recordClass.useBasket || resultType.type !== 'step' ? null :
-        <div className="ResultTableButton">
+  );
+
+  const addToBasketNode = (
+    !recordClass.useBasket || resultType.type !== 'step'
+      ? null
+      : <div className="ResultTableButton">
           <button type="button"
             className="btn"
             title={userIsGuest ? 'You must login to use baskets' : 'Add all records returned by this search to your basket'}
@@ -116,12 +128,23 @@ function ResultTable(props: Props) {
             <IconAlt fa="shopping-basket"/> Add to Basket
           </button>
         </div>
-      }
-      <div className="ResultTableButton">
-        <button className="btn" type="button" onClick={() => showHideAddColumnsDialog(true)}>
-          <IconAlt fa="cog"/> Add Columns
-        </button>
-      </div>
+  );
+
+  const addColumnsNode = (
+    <div className="ResultTableButton">
+      <button className="btn" type="button" onClick={() => showHideAddColumnsDialog(true)}>
+        <IconAlt fa="cog"/> Add Columns
+      </button>
+    </div>
+  );
+
+  return (
+    <Mesa state={tableState}>
+      {renderTableActions({
+        addColumnsNode,
+        addToBasketNode,
+        downloadLinkNode
+      })}
     </Mesa>
   );
 }
@@ -289,4 +312,14 @@ function getColumns({
     }));
 
   return recordClass.useBasket ? [basketColumn, ...answerColumns] : answerColumns;
+}
+
+function defaultRenderTableActions(props: TableActionsProps) {
+  return (
+    <>
+      {props.downloadLinkNode}
+      {props.addToBasketNode}
+      {props.addColumnsNode}
+    </>
+  );
 }


### PR DESCRIPTION
Relates to #209

This PR introduces two small enhancements to accommodate Gene List UD exports:
1. The `getTemporaryResultPath` WdkService method is updated to allow step id inputs
2. The `ResultTable` is given an optional `renderToolbarContent` prop. In particular, this allows custom export option(s) to be displayed, and/or the default buttons to be displayed in a custom way. [Example use of the former](https://github.com/VEuPathDB/ApiCommonWebsite/blob/7b362f928bfbd945dec5ec0dc6ab2f1a88e26947/Site/webapp/wdkCustomization/js/client/components/records/TranscriptRecordClasses.TranscriptRecordClass.jsx#L89-L140).

(Something to consider now or in the near future: is "custom export option(s)" a common enough use case to warrant a special `customExports` prop?)