### PR TITLE
Add interactive attribute to HelpIcon tooltip

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/Icon/HelpIcon.tsx
+++ b/Client/src/Components/Icon/HelpIcon.tsx
@@ -14,6 +14,7 @@ export default function HelpIcon (props: Props) {
     <Tooltip
       css={{}}
       title={props.children}
+      interactive
     >
       <button type="button" className="link HelpTrigger">
         <Icon fa="question-circle"/>


### PR DESCRIPTION
The `HelpIcon` tooltip component used in the screenshot below did not allow a user to interact with the link. Adding the `interactive` [attribute to the React Tooltip component](https://v4.mui.com/components/tooltips/#interactive) fixes this issue.

![image](https://user-images.githubusercontent.com/69446567/172484296-18ebc154-2f2a-41e9-859e-0069ec69563d.png)