### PR TITLE
Tweak pluralisation logic in TableToolbar counter

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/Mesa/Ui/TableToolbar.jsx
+++ b/Client/src/Components/Mesa/Ui/TableToolbar.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Icon from 'wdk-client/Components/Mesa/Components/Icon';
 import TableSearch from 'wdk-client/Components/Mesa/Ui/TableSearch';
 import RowCounter from 'wdk-client/Components/Mesa/Ui/RowCounter';
 
@@ -26,7 +25,7 @@ class TableToolbar extends React.PureComponent {
   }
 
   renderSearch () {
-    const { options, uiState, eventHandlers } = this.props;
+    const { uiState, eventHandlers } = this.props;
     const { onSearch } = eventHandlers;
     const { searchQuery } = uiState;
 
@@ -52,7 +51,7 @@ class TableToolbar extends React.PureComponent {
     const isSearching = uiState.searchQuery && uiState.searchQuery.length;
 
     const count = totalRows ? totalRows : rows.length;
-    const noun = (isSearching ? 'result' : 'row') + (count % rowsPerPage === 1 ? '' : 's');
+    const noun = (isSearching ? 'result' : 'row') + ((count - filteredRowCount) === 1 ? '' : 's');
     const start = !isPaginated ? null : ((pagination.currentPage - 1) * rowsPerPage) + 1;
     const end = !isPaginated ? null : (start + rowsPerPage > (count - filteredRowCount) ? (count - filteredRowCount) : (start - 1) + rowsPerPage);
 


### PR DESCRIPTION
While working [to add a counter](https://github.com/VEuPathDB/ApiCommonWebsite/issues/72) in an `ApiCommonWebsite` component, I noticed the pluralization seemed off in the counter.

The existing line `const noun = (isSearching ? 'result' : 'row') + (count % rowsPerPage === 1 ? '' : 's');` results in a singular noun when the count is 16 and the rowsPerPage are 5, yet there are multiple rows being displayed.

I replaced the modulo condition with `count - filteredRowCount === 1` which seemed to consistently provide the pluralization I was expecting.