### PR TITLE
Export InlineRecordAttributeSection and BlockRecordAttributeSection 

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/Records/RecordAttributes/RecordAttributeSection.tsx
+++ b/Client/src/Views/Records/RecordAttributes/RecordAttributeSection.tsx
@@ -41,7 +41,7 @@ function RecordAttributeSection(props: Props) {
 export default wrappable(RecordAttributeSection);
 
 /** Display attribute name and value on a single line */
-function InlineRecordAttributeSection(props: Props) {
+export function InlineRecordAttributeSection(props: Props) {
   let { attribute, record, recordClass, title } = props;
   let { displayName, help, name } = attribute;
   return (
@@ -71,7 +71,7 @@ function InlineRecordAttributeSection(props: Props) {
 }
 
 /** Display attribute name and value in a collapsible section */
-function BlockRecordAttributeSection(props: Props) {
+export function BlockRecordAttributeSection(props: Props) {
   const { attribute, record, recordClass, isCollapsed, onCollapsedChange, title } = props;
   const { displayName, help, name } = attribute;
 


### PR DESCRIPTION
This is to support the new alphafold visualization. It is currently implemented as a record attribute. We want it to be in a collapsible section.