### PR TITLE
Use meta.viewTotalCount for pagination to account for filtering

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/Client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -76,7 +76,7 @@ function ResultTable(props: Props) {
     pagination: {
       currentPage: Math.ceil((answer.meta.pagination.offset + 1) / answer.meta.pagination.numRecords),
       rowsPerPage: answer.meta.pagination.numRecords,
-      totalRows: answer.meta.totalCount
+      totalRows: answer.meta.viewTotalCount
     }
   };
   const selectedIdsSet = new Set(selectedIds);


### PR DESCRIPTION
Together with [this work in ApiCommonWebsite](https://github.com/VEuPathDB/ApiCommonWebsite/pull/86), this addresses a paging error when the global view filter changes ([Redmine #48424](https://redmine.apidb.org/issues/48424)).