### PR TITLE
display empty attributes on record page, with indication that no data is available

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/Records/RecordAttributes/RecordAttribute.jsx
+++ b/Client/src/Views/Records/RecordAttributes/RecordAttribute.jsx
@@ -1,9 +1,14 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import { renderAttributeValue, wrappable } from 'wdk-client/Utils/ComponentUtils';
 
 /** Attribute value */
 function RecordAttribute(props) {
-  let { record, attribute } = props;
+  const { record, attribute } = props;
+  const value = record.attributes[attribute.name];
+  if (value == null) return (
+    <p><em>No data available</em></p>
+  );
   return renderAttributeValue(record.attributes[attribute.name], null, 'div');
 }
 

--- a/Client/src/Views/Records/RecordAttributes/RecordAttributeSection.tsx
+++ b/Client/src/Views/Records/RecordAttributes/RecordAttributeSection.tsx
@@ -29,8 +29,7 @@ function RecordAttributeSection(props: Props) {
       : value.displayText != null ? stripHTML(value.displayText).length
       : value.url.length;
   }, [value])
-  if (value == null) return null;
-  if (textLength !== -1 && textLength < 150) return (
+  if (textLength < 150) return (
     <InlineRecordAttributeSection {...props} />
   )
   else return (


### PR DESCRIPTION
Previously, we were hiding such attributes completely. With the change to show all attributes in the TOC, it makes more sense to include them on the page.

![image](https://user-images.githubusercontent.com/365139/183703220-3d02165f-3762-498d-99d8-179d78a9dc6c.png)
