### PR TITLE
Fix dimension error in Genetic variation plot and set overflow-y: auto

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
@@ -98,6 +98,7 @@
   position: relative;
   padding: 1em;
   margin-top: 1em;
+  min-width: 200px;
 }
 .filter-param .chart {
   height: 200px;

--- a/Client/src/Views/Records/Record.css
+++ b/Client/src/Views/Records/Record.css
@@ -122,7 +122,7 @@
 
 .wdk-RecordNavigationSection .wdk-CheckboxTree > .wdk-CheckboxTreeList {
   max-height: 70vh;
-  overflow-y: scroll;
+  overflow-y: auto;
   position: relative;
 }
 


### PR DESCRIPTION
Fixes [ issue](https://github.com/VEuPathDB/ApiCommonWebsite/issues/90)

Also went ahead and reverted the `CheckboxTree` in the record navigation sidebar to use `overflow-y: auto` since `overflow-y: scroll` resulted in a permanent scrollbar, either in an enabled or disabled state.