### PR TITLE
Handle truncation via CSS

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
+++ b/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { truncate } from 'lodash';
 import { RecordInstance, AttributeField } from 'wdk-client/Utils/WdkModel';
-import {wrappable} from 'wdk-client/Utils/ComponentUtils';
+import {safeHtml, wrappable} from 'wdk-client/Utils/ComponentUtils';
 
 interface AttributeCellProps {
   attribute: AttributeField;
@@ -17,15 +17,14 @@ function AttributeCell({
   if (value == null) return null;
 
   if (typeof value === 'string') {
-    const truncatedValue = truncateValue(value, attribute.truncateTo);
-    return (
-      <div
-        title={truncatedValue !== value ? value : undefined}
-        dangerouslySetInnerHTML={{
-          __html: truncatedValue
-        }}
-      />
-    );
+    return safeHtml(value, {
+      style: {
+        maxWidth: `${attribute.truncateTo}ch`,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }
+    }, 'div')
   }
 
   const { url, displayText } = value;


### PR DESCRIPTION
This PR uses a more robust method for truncating text of textAttributes in the result table summary view. The previous method was causing invalid HTML to be inserted into the DOM by React, which was rendering the cell empty.