### PR TITLE
Refine user promise cache management + fix tag nesting warning

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Service/Mixins/UsersService.ts
+++ b/Client/src/Service/Mixins/UsersService.ts
@@ -19,7 +19,8 @@ export default (base: ServiceBase) => {
   function updateCurrentUser(user: User) {
     let url = '/users/current';
     let data = JSON.stringify(user);
-    return currentUserPromise = base._fetchJson<void>('put', url, data).then(() => user);
+    return base._fetchJson<void>('put', url, data)
+      .then(() => currentUserPromise = Promise.resolve(user));
   }
 
   function updateCurrentUserPassword(oldPassword: string, newPassword: string) {

--- a/Client/src/Views/User/UserFormContainer.jsx
+++ b/Client/src/Views/User/UserFormContainer.jsx
@@ -73,9 +73,7 @@ function OutroComponent(props) {
         that enable  collecting, archiving, updating, and integrating a variety of genomics and related&nbsp;
         research data relevant to infectious diseases, and pathogens and their interaction with hosts.
       </p>
-      <p>
-        <VisitOtherBrc {...props}/>
-      </p>
+      <VisitOtherBrc {...props}/>
       <p>
         Sign up for cross-BRC email alerts <a target="_blank" href="https://lists.brcgateway.org/mailman/listinfo/brc-all">here</a>.
       </p>
@@ -96,12 +94,12 @@ export function VisitOtherBrc({user}) {
     "&affiliation=" + clean(user.properties.organization) +
     "&interests=" + clean(user.properties.interests);
   return (
-    <div style={{margin:"1.5em 0"}}>
+    <p style={{margin:"1.5em 0"}}>
       Visit our partner Bioinformatics Resource Center,&nbsp;
       <a target="_blank" href="https://www.bv-brc.org">BV-BRC</a>, and&nbsp;
       <a target="_blank" href="https://www.bv-brc.org/login">log in</a> there or&nbsp;
       <a target="_blank" href={'https://www.bv-brc.org/register' + userDataQueryString}>register</a>.
-    </div>
+    </p>
   );
 }
 


### PR DESCRIPTION
Solution as discussed in scrum.  I think everything is working as expected coupling these changes with [a back-end fix](https://github.com/VEuPathDB/WDK/commit/6458ca290a36422a72b3d452f2834f014ce879cf) to update the user object on the session after update.  Together, these should address:

1. User object being cached in back-end session is not updated during profile updates
2. User trying to reset email to email assigned to existing account gets bad message (client mishandles 409)
3. After 409 occurs, currentUser promise is broken and can only be fixed with a getCurrentUser({force:true})
4. User successfully updating email address, user gets logged out (race condition between profile update and prefs update)

Note: after approval, this commit should be added to the live sites.