### PR TITLE
Allow for optionally visible body in radio list options

### DIFF
--- a/Client/src/Components/InputControls/RadioList.tsx
+++ b/Client/src/Components/InputControls/RadioList.tsx
@@ -14,6 +14,7 @@ type Props = {
     value: string;
     description?: string;
     disabled?: boolean;
+    body?: ReactNode;
   }>;
   /** Value of the radio input element that should be checked **/
   value?: string;
@@ -69,6 +70,11 @@ class RadioList extends React.Component<Props> {
                 </HelpIcon>
               }
             </label>
+          {item.body &&
+            <div style={item.value === this.props.value ? {} : {display: "none"}}>
+              {item.body}
+            </div>
+          }
           </li>
         ))}
       </ul>


### PR DESCRIPTION
I'd like this option for my sequence retrieval work. We wanted a tree-like UI to accommodate a few different secondary selections, and this change lets me have a radio list that recursively includes other components.


 The code that will use this option is still in flux, but you can see it here: https://github.com/wbazant/EbrcWebsiteCommon/commit/5e74e9df31a849b6541b3bba495767d4eb2108ec#diff-1adc024b585400299079042b58211d4205b5bae691c1871fe8838002fc13e141R145. 


Question: this option is potentially too general, since in my case a few options have these optionally visible bodies, they all have headings, and it's up to me to make them consistent in the client code. I could potentially move this into the component:
```
<div {item.value === this.props.value ? {} : {display: "none"}} >
      <div style={{margin:'0.5em'}}>{{optionSecondaryChoiceTtitle}}</div>
      {{optionSecondaryChoiceBody}}
</div>
```
Would that be better? 

You can see it working on https://wbazant.plasmodb.org/plasmo.wbazant - try download genes, and choose a new option , 'bed'

# Screenshots
## client code
![Screenshot from 2022-09-20 15-30-03](https://user-images.githubusercontent.com/16976512/191285650-a94dfd6a-6d3c-42a5-abd2-92dd8afc49cf.png)

## option 1
![Screenshot from 2022-09-20 15-26-38](https://user-images.githubusercontent.com/16976512/191285412-4be82535-ec3b-4dcb-98d4-fe11d4e3a0d9.png)

## option 2
![Screenshot from 2022-09-20 15-26-32](https://user-images.githubusercontent.com/16976512/191285419-29791c87-bfd8-4895-83e3-8271099687f7.png)

## option 3
![Screenshot from 2022-09-20 15-26-23](https://user-images.githubusercontent.com/16976512/191285421-b5be3eee-4ed3-4ed0-907e-1140a14c0e1f.png)

