### PR TITLE
Handle null value for `str` parameter

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Utils/ComponentUtils.tsx
+++ b/Client/src/Utils/ComponentUtils.tsx
@@ -232,7 +232,8 @@ function logShallowComparison<P extends AnyObject>(obj1: P, obj2: P, label: stri
 export function safeHtml<P>(str: string, props?: P, Component?: React.ComponentClass<P>): JSX.Element;
 export function safeHtml<P>(str: string, props?: P, Component?: React.StatelessComponent<P>): JSX.Element;
 export function safeHtml<P>(str: string, props?: P, Component?: string): JSX.Element;
-export function safeHtml<P>(str = '', props?: P, Component: any = 'span'): JSX.Element {
+export function safeHtml<P>(str: string | null, props?: P, Component: any = 'span'): JSX.Element {
+  str = str ?? '';
   if (str.indexOf('<') === -1) {
     return <Component {...props}>{str}</Component>
   }


### PR DESCRIPTION
This fixes cases where a `null` value is passed in, such as the gene page's transcriptomics table.