### PR TITLE
Update UnhandledErrorStoreModule.ts

### DIFF
--- a/Client/src/StoreModules/UnhandledErrorStoreModule.ts
+++ b/Client/src/StoreModules/UnhandledErrorStoreModule.ts
@@ -37,7 +37,8 @@ export function reduce(state: State = initialState, action: Action): State {
 // TODO Allow this to be configured by wdk-client consumer
 function ignoreError(message: string): boolean {
   return (
-    /ResizeObserver loop limit exceeded/.test(message)
+    /ResizeObserver loop limit exceeded/.test(message) ||
+    /empty textures are not allowed/.test(message)
   )
 }
 


### PR DESCRIPTION
adding "empty textures are not allowed", it pops up pretty frequently and doesnt add anything.. 
might be related to new viz alphafold