### PR TITLE
Refactor how AttributeCell handles truncation

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Resolves #260 

Added some logic to prevent `Tooltip` from rendering in cells that exceed the truncation limit but don't overflow the `maxWidth`.