### PR TITLE
Wire up column filters in record tables

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/package.json
+++ b/Client/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "@veupathdb/components": "^0.19.7",
-    "@veupathdb/coreui": "^0.18.14",
+    "@veupathdb/coreui": "^0.18.16",
     "@veupathdb/react-scripts": "^2.0.0",
     "babel-eslint": "^8.0.1",
     "babel-jest": "^23.1.2",
@@ -94,7 +94,7 @@
   },
   "peerDependencies": {
     "@veupathdb/components": "^0.19.7",
-    "@veupathdb/coreui": "^0.18.14",
+    "@veupathdb/coreui": "^0.18.16",
     "notistack": "^1.0.10",
     "react": ">=16.14",
     "react-dom": ">=16.14",

--- a/Client/src/Components/DataTable/DataTable.tsx
+++ b/Client/src/Components/DataTable/DataTable.tsx
@@ -166,7 +166,7 @@ class DataTable extends PureComponent<Props, State> {
     this._setup();
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
     if (this._dataTable == null) return;
 
     let columnsChanged = didPropChange(this, prevProps, 'columns')
@@ -175,6 +175,8 @@ class DataTable extends PureComponent<Props, State> {
     let widthChanged = didPropChange(this, prevProps, 'width');
     let heightChanged = didPropChange(this, prevProps, 'height');
     let expandedRowsChanged = didPropChange(this, prevProps, 'expandedRows');
+    let searchTermChanged = didPropChange(this, prevProps, 'searchTerm');
+    let columnFiltersChanged = didStateChange(this, prevState, 'selectedColumnFilters');
 
     this._isRedrawing = true;
 
@@ -198,7 +200,11 @@ class DataTable extends PureComponent<Props, State> {
 
       if (expandedRowsChanged) {
         this._updateExpandedRows(this._dataTable);
-        // needsRedraw = true;
+      }
+      
+      if (columnFiltersChanged || searchTermChanged) {
+        const indexesOfSelectedFilters = this.state.selectedColumnFilters.map(colFilter => this.props.columns.findIndex(col => col.name === colFilter));
+        this._updateSearch(this._dataTable, this.props.searchTerm ?? this._searchTerm, indexesOfSelectedFilters);
       }
 
       if (needsRedraw && this._dataTable) {
@@ -373,10 +379,11 @@ class DataTable extends PureComponent<Props, State> {
   }
 
   _updateSearch(dataTable: DataTables.Api, searchTerm: string, indexesOfSelectedFilters: number[]) {
+    // reset search criteria to sync state/props with the jquery table render
+    dataTable.columns().search('')
     const queryTerms = parseSearchQueryString(searchTerm);
     const searchTermRegex = areTermsInStringRegexString(queryTerms);
-    console.log({dataTable, searchTerm, indexesOfSelectedFilters})
-    if (!this.state.selectedColumnFilters.length) {
+    if (!indexesOfSelectedFilters.length) {
       dataTable.search(searchTermRegex, true, false, true).draw();
     } else {
       dataTable.columns(indexesOfSelectedFilters).search(searchTermRegex, true, false, true).draw();
@@ -505,7 +512,6 @@ class DataTable extends PureComponent<Props, State> {
   render() {
     let { searchable = true, childRow, columns } = this.props;
     const filterAttributes = columns.filter(col => col.isDisplayable).map(col => ({display: col.displayName, value: col.name}));
-    const indexesOfSelectedFilters = columns.map((attr, index) => this.state.selectedColumnFilters.includes(attr.name) ? index : -1).filter(index => index >= 0);
     return (
       <div className="MesaComponent">
         {searchable && (
@@ -519,25 +525,37 @@ class DataTable extends PureComponent<Props, State> {
                 className="wdk-DataTableSearchBox"
                 placeholderText="Search this table..."
                 onSearchTermChange={(searchTerm: string) => {
+                  // _updateSearch is called in componentDidUpdate when props.searchTerm changes
                   this.props.onSearchTermChange?.(searchTerm);
 
                   if (this.props.searchTerm != null) {
                     this._searchTerm = '';
                   } else {
                     this._searchTerm = searchTerm;
+                    // JM: unclear if this is used, but _updateSearch will be called when props.searchTerm does not exist
+                    this._dataTable && 
+                      this._updateSearch(
+                          this._dataTable,
+                          searchTerm,
+                          this.state.selectedColumnFilters.map(colFilter => this.props.columns.findIndex(col => col.name === colFilter))
+                        );
                   }
 
-                  this._dataTable && this._updateSearch(this._dataTable, searchTerm, indexesOfSelectedFilters);
                 }}
                 delayMs={0}
                 iconName=''
+                cancelBtnRightMargin='3em'
               />
               <div style={{position: 'relative', width: 0, right: '2.75em', top: '0.25em'}}>
               <Tooltip content="Show search fields">
                 <button 
                   className="fa fa-caret-down"
                   style={{background: 'none', border: 'none'}}
-                  onClick={this.toggleFilterFieldSelector}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    this.toggleFilterFieldSelector();
+                    }
+                  }
                 />
               </Tooltip>
               </div>
@@ -630,6 +648,11 @@ function didPropChange(component: Component<Props, any>, prevProps: Props, propN
   return !isEqual(component.props[propName], prevProps[propName]);
 }
 
+/** Return boolean indicating if a state's value has changed. */
+function didStateChange(component: Component<Props, State>, prevState: State, stateName: keyof State) {
+  return !isEqual(component.state[stateName], prevState[stateName]);
+}
+
 type DataFilterAttribute = {
   value: string;
   display: string;
@@ -676,14 +699,12 @@ function DataTableFilterSelector({filterAttributes, selectedColumnFilters, onCol
         onChange={onColumnFilterChange}
         linksPosition={LinksPosition.Top}
       />
-
       <div className="wdk-Answer-filterFieldSelectorCloseIconWrapper">
         <button
           className="fa fa-close wdk-Answer-filterFieldSelectorCloseIcon"
           onClick={toggleFilterFieldSelector}
         />
-      </div>
-    
+      </div>    
     </TabbableContainer>
   )
 }

--- a/Client/src/Components/DataTable/DataTable.tsx
+++ b/Client/src/Components/DataTable/DataTable.tsx
@@ -448,8 +448,8 @@ class DataTable extends PureComponent<Props, State> {
     else {
       let props = { rowIndex: row.index(), rowData: row.data() };
       this.setState(state => ({
+        ...state,
         childRows: uniqBy([ ...state.childRows, [ childRowContainer, props ] ], ([node]) => node),
-        selectedColumnFilters: [...state.selectedColumnFilters]
       }));
     }
   }
@@ -498,8 +498,6 @@ class DataTable extends PureComponent<Props, State> {
       ...state,
       selectedColumnFilters: value,
     }))
-    // const indexesOfSelectedFilters = this.props.columns.map((attr, index) => this.state.selectedColumnFilters.includes(attr.name) ? index : -1).filter(index => index >= 0);
-    // this._dataTable && this._updateSearch(this._dataTable, this.props.searchTerm ?? this._searchTerm, indexesOfSelectedFilters)
   }
 
   toggleFilterFieldSelector() {
@@ -540,7 +538,6 @@ class DataTable extends PureComponent<Props, State> {
                           this.state.selectedColumnFilters.map(colFilter => this.props.columns.findIndex(col => col.name === colFilter))
                         );
                   }
-
                 }}
                 delayMs={0}
                 iconName=''

--- a/Client/src/Components/SearchBox/RealTimeSearchBox.tsx
+++ b/Client/src/Components/SearchBox/RealTimeSearchBox.tsx
@@ -41,6 +41,8 @@ type Props = {
   /** Delay in milliseconds after last character typed until onSearchTermChange is called.  Defaults to 250. */
   delayMs?: number;
 
+  /** Additional right positioning for the "cancel" button when used in DataTable's column filters */
+  cancelBtnRightMargin?: React.CSSProperties['right'];
 }
 
 type State = {
@@ -127,7 +129,7 @@ export default class RealTimeSearchBox extends Component<Props, State> {
   }
 
   render() {
-    let { className, helpText, placeholderText, autoFocus, iconName } = this.props;
+    let { className, helpText, placeholderText, autoFocus, iconName, cancelBtnRightMargin } = this.props;
     let searchTerm = this.state.searchTerm;
     let isActiveSearch = searchTerm.length > 0;
     let activeModifier = isActiveSearch ? 'active' : 'inactive';
@@ -146,7 +148,7 @@ export default class RealTimeSearchBox extends Component<Props, State> {
             value={searchTerm}
           />
           <i className={`fa fa-${iconName} ${searchIconClassName}`}/>
-          <button className={cancelBtnClassName}
+          <button className={cancelBtnClassName} style={cancelBtnRightMargin ? {right: cancelBtnRightMargin} : undefined}
             type="button" onClick={this.handleResetClick}>
             <i className={"fa fa-close " + cancelIconClassName}/>
           </button>

--- a/Client/yarn.lock
+++ b/Client/yarn.lock
@@ -1328,10 +1328,10 @@
     react-transition-group "^4.4.1"
     shape2geohash "^1.2.5"
 
-"@veupathdb/coreui@^0.18.14":
-  version "0.18.14"
-  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.18.14.tgz#ea524dc02401d87c7a4ffe76d6b60ed3301f51c2"
-  integrity sha512-aa13Xugh1/ngybkIUvanOqHwpsqd850iTTFH2MHAxX5pMgZKLe4iNmlsw0o0YJ4PK/yT14Apq58zdip+RSpIXQ==
+"@veupathdb/coreui@^0.18.16":
+  version "0.18.16"
+  resolved "https://registry.yarnpkg.com/@veupathdb/coreui/-/coreui-0.18.16.tgz#9d7ebdc54e5a0ccaaf00a24a2a52fedd4b369fed"
+  integrity sha512-+wBEE2nakVh2cySdjhIaoKKYjWE8rdP1j43weYUvlq4nvFBnfv7ElKf2HhXow6q/AskoTaNqMG+0+B+e1xFvcA==
   dependencies:
     "@react-hook/size" "^2.1.2"
     core-js "^3.25.3"


### PR DESCRIPTION
Resolves [this Redmine request](https://redmine.apidb.org/issues/40708).

Uses the [search() method](https://datatables.net/reference/api/search()) from the jQuery `DataTable`'s API.

**Note**: The background when hovering `select all` and `clear all` will be removed via https://github.com/VEuPathDB/CoreUI/pull/130