### PR TITLE
add top offset prop for WorkspaceNavigation

### DIFF
--- a/Client/src/Components/Workspace/WorkspaceNavigation.tsx
+++ b/Client/src/Components/Workspace/WorkspaceNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, CSSProperties } from "react";
 import { makeClassNameHelper } from "wdk-client/Utils/ComponentUtils";
 import { NavLink, NavLinkProps } from "react-router-dom";
 
@@ -15,14 +15,16 @@ interface Props {
   heading: ReactNode;
   routeBase: string;
   items: WorkspaceNavigationItem[];
+  // add offset at the top of this WorkspaceNavigation to avoid overlap with other element
+  topOffset?: CSSProperties['top'],
 }
 
 const cx = makeClassNameHelper('WorkspaceNavigation');
 
 export default function WorkspaceNavigation(props: Props) {
-  const { heading, items, routeBase } = props;
+  const { heading, items, routeBase, topOffset } = props;
   return (
-    <div className={cx()}>
+    <div className={cx()} style={{ top: topOffset }}>
       <h1>{heading}</h1>
       {items.map((item, index) => (
         <NavLink


### PR DESCRIPTION
This is for addressing https://github.com/VEuPathDB/web-eda/issues/1518. Basically, a topOffset prop is added at WorkspaceNavigation component so that it can be controlled from, e.g., web-eda: https://github.com/VEuPathDB/web-eda/blob/09a98d00382c0ba6b210ec1769a66ba003795057/src/lib/workspace/AnalysisPanel.tsx#L282 by setting like 
`topOffset={'3em'}`

Since inline style has higher priority than class/className, this will override it. Any better idea, @dmfalke?