### PR TITLE
Fix break in scrolling logic from CSS changes to FieldList's FieldNode component

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/AttributeFilter/FieldList.jsx
+++ b/Client/src/Components/AttributeFilter/FieldList.jsx
@@ -1,8 +1,7 @@
 import { memoize, uniq } from 'lodash';
 import PropTypes from 'prop-types';
-import React, {useLayoutEffect, useRef} from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import { scrollIntoViewIfNeeded } from 'wdk-client/Utils/DomUtils';
 import { Seq } from 'wdk-client/Utils/IterableUtils';
 import { areTermsInString, makeSearchHelpText } from 'wdk-client/Utils/SearchUtils';
 import { preorderSeq } from 'wdk-client/Utils/TreeUtils';
@@ -156,21 +155,13 @@ function getNodeSearchString(valuesMap) {
 }
 
 
-function FieldNode({node, searchTerm, isActive, handleFieldSelect }) {
-  const nodeRef = useRef(null);
-
-  useLayoutEffect(() => {
-    if (isActive && nodeRef.current && nodeRef.current.offsetParent) {
-      scrollIntoViewIfNeeded(nodeRef.current.offsetParent);
-    }
-  }, [ isActive, nodeRef.current, searchTerm ])
+function FieldNode({node, isActive, handleFieldSelect }) {
 
   return (
     <Tooltip content={node.field.description} hideDelay={0}>
       {isFilterField(node.field)
       ? (
         <a
-          ref={nodeRef}
           className={'wdk-AttributeFilterFieldItem' +
             (isActive ? ' wdk-AttributeFilterFieldItem__active' : '')}
           href={'#' + node.field.term}

--- a/Client/src/Components/AttributeFilter/FieldList.jsx
+++ b/Client/src/Components/AttributeFilter/FieldList.jsx
@@ -1,7 +1,8 @@
 import { memoize, uniq } from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
+import { scrollIntoViewIfNeeded } from 'wdk-client/Utils/DomUtils';
 import { Seq } from 'wdk-client/Utils/IterableUtils';
 import { areTermsInString, makeSearchHelpText } from 'wdk-client/Utils/SearchUtils';
 import { preorderSeq } from 'wdk-client/Utils/TreeUtils';
@@ -155,13 +156,21 @@ function getNodeSearchString(valuesMap) {
 }
 
 
-function FieldNode({node, isActive, handleFieldSelect }) {
+function FieldNode({node, isActive, searchTerm, handleFieldSelect }) {
+  const nodeRef = useRef(null);
+
+  useLayoutEffect(() => {
+    if (isActive && nodeRef.current && nodeRef.current.offsetParent) {
+      scrollIntoViewIfNeeded(nodeRef.current.offsetParent);
+    }
+  }, [ isActive, nodeRef.current, searchTerm ])
 
   return (
     <Tooltip content={node.field.description} hideDelay={0}>
       {isFilterField(node.field)
       ? (
         <a
+          ref={nodeRef}
           className={'wdk-AttributeFilterFieldItem' +
             (isActive ? ' wdk-AttributeFilterFieldItem__active' : '')}
           href={'#' + node.field.term}

--- a/Client/src/Components/AttributeFilter/ServerSideAttributeFilter.jsx
+++ b/Client/src/Components/AttributeFilter/ServerSideAttributeFilter.jsx
@@ -19,7 +19,7 @@ function ServerSideAttributeFilter (props) {
   }
 
   return (
-    <div>
+    <div style={{overflowX: 'auto', marginRight: '1em'}}>
       {hideFilterPanel || <FilterList {...props} /> }
 
       {/* Main selection UI */}

--- a/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
+++ b/Client/src/Views/Question/Params/FilterParamNew/FilterParam.css
@@ -187,6 +187,9 @@
   position: relative;
   min-height: 36em;
 }
+.filters {
+  display: flex;
+}
 .filter-param .filters-server-side {
   border: 1px solid #999;
 }
@@ -194,20 +197,6 @@
   width: 25%;
   padding-left: 8px;
   padding-right: 8px;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-}
-.filter-param .wdk-CheckboxTree {
-  height: calc(100% - 7em);
-}
-.filter-param .wdk-CheckboxTree > .wdk-CheckboxTreeList {
-  padding-top: .5em;
-  padding-bottom: 1.5em;
-  border-bottom: 1px solid #ccc;
-  position: relative;
-  height: 100%;
-  overflow: auto;
 }
 .filter-param .wdk-AttributeFilterFieldParent,
 .filter-param .wdk-AttributeFilterFieldItem {
@@ -226,9 +215,7 @@
 }
 .filter-param .field-detail {
   width: 75%;
-  margin-left: 25%;
   padding: 0 1rem;
-  position: relative;
 }
 .filter-param .unknown-count {
   font-size: 1.1em;
@@ -241,9 +228,6 @@
   width: 100%;
   margin: 0;
   padding: 0;
-}
-.filter-param .field-description {
- /* margin-bottom: 1em; */
 }
 .filter-param .field-detail h4 {
   margin-top: 4em;


### PR DESCRIPTION
Resolves `Redmine #50182 - gene page: isolate alignments: filterParam: selecting a variable jumps page to top`

I fear this may be too simplistic. I've removed the logic from `FieldNode` that adjusts page position because it doesn't seem appropriate in the gene records context. Doing so fixed the jump to the top of the page.