### PR TITLE
 confine bin width to int when all values are ints

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/AttributeFilter/Histogram.jsx
+++ b/Client/src/Components/AttributeFilter/Histogram.jsx
@@ -572,7 +572,7 @@ var Histogram = (function() {
                   <tr>
                     <th>Bin width:</th>
                     <td>
-                      <input type="number" min={1} value={this.state.uiState.binSize} onFocus={autoSelectOnFocus} onChange={e => this.setXAxisBinSize(eventToNumber(e))}/>
+                      <input type="number" min={0} value={this.state.uiState.binSize} onFocus={autoSelectOnFocus} onChange={e => this.setXAxisBinSize(eventToNumber(e))}/>
                       <em> When bin size = 0, the count of discrete values is shown</em>
                     </td>
                   </tr>
@@ -717,13 +717,4 @@ function eventToNumber(event) {
 
 function autoSelectOnFocus(event) {
   event.target.select();
-}
-
-function formatBinWidth(binSize, allValuesAreIntegers) {
-  if (!allValuesAreIntegers) return binSize;
-  if (binSize < 1) return 1;
-  return Math.ceil(binSize);
-}
-function name(params) {
-  
 }

--- a/Client/src/Components/AttributeFilter/Histogram.jsx
+++ b/Client/src/Components/AttributeFilter/Histogram.jsx
@@ -13,6 +13,7 @@ import { CollapsibleSection, IconAlt } from 'wdk-client/Components';
 import Tooltip from 'wdk-client/Components/Overlays/Tooltip';
 
 const DAY = 1000 * 60 * 60 * 24;
+
 const IGNORED_UI_STATE_PROPERTIES = ['loading', 'valid', 'errorMessage'];
 
 var distributionEntryPropType = PropTypes.shape({

--- a/Client/src/Components/AttributeFilter/Histogram.jsx
+++ b/Client/src/Components/AttributeFilter/Histogram.jsx
@@ -13,7 +13,6 @@ import { CollapsibleSection, IconAlt } from 'wdk-client/Components';
 import Tooltip from 'wdk-client/Components/Overlays/Tooltip';
 
 const DAY = 1000 * 60 * 60 * 24;
-
 const IGNORED_UI_STATE_PROPERTIES = ['loading', 'valid', 'errorMessage'];
 
 var distributionEntryPropType = PropTypes.shape({
@@ -138,6 +137,12 @@ var Histogram = (function() {
       }), { min: Infinity, max: -Infinity });
     }
 
+    isEveryValueAnInteger(distribution) {
+      return distribution.every(
+        ({ value }) => Number.isInteger(value)
+      );
+    }
+
     getDefaultBinSize(props) {
       if (props.chartType === 'date') return 1;
       const { min, max } = this.getRange(props.distribution);
@@ -146,8 +151,9 @@ var Histogram = (function() {
       const padding = (max - min) / 100;
       // Compute number of bins using Sturge's rule
       const numBins = Math.ceil(Math.log2(numVals)) + 1;
-      const binSize = (padding + max - min) / numBins;
-      return binSize || (max - Math.min(0, min)) / 10;
+      const binSize = (padding + max - min) / numBins || (max - Math.min(0, min)) / 10;
+      if (!this.isEveryValueAnInteger(props.distribution)) return binSize;
+      return Math.ceil(binSize);
     }
 
     getXAxisMinMax(props) {
@@ -566,7 +572,7 @@ var Histogram = (function() {
                   <tr>
                     <th>Bin width:</th>
                     <td>
-                      <input type="number" min={0} value={this.state.uiState.binSize} onFocus={autoSelectOnFocus} onChange={e => this.setXAxisBinSize(eventToNumber(e))}/>
+                      <input type="number" min={1} value={this.state.uiState.binSize} onFocus={autoSelectOnFocus} onChange={e => this.setXAxisBinSize(eventToNumber(e))}/>
                       <em> When bin size = 0, the count of discrete values is shown</em>
                     </td>
                   </tr>
@@ -711,4 +717,13 @@ function eventToNumber(event) {
 
 function autoSelectOnFocus(event) {
   event.target.select();
+}
+
+function formatBinWidth(binSize, allValuesAreIntegers) {
+  if (!allValuesAreIntegers) return binSize;
+  if (binSize < 1) return 1;
+  return Math.ceil(binSize);
+}
+function name(params) {
+  
 }


### PR DESCRIPTION
Maybe resolves: #270. Feedback, please!

| Before | After |
|---|---|
| ![Before](https://user-images.githubusercontent.com/24446573/212404408-758dc07a-b859-4046-b8f3-d84256fa8908.png) | ![After](https://user-images.githubusercontent.com/24446573/212404786-124f3196-b9c6-4796-a003-629959378d99.png) |

**Notes**:
- This resolves the default value that the viz is loaded with. Users are free to change use decimals if they want.
- I don't know if there are any tests covering this.
- I also may have overlooked one or many things in my newness.

**Questions**:
- Do we use any code formatting tools?
- What does testing look like? How can I know how many bugs I just introduced with my change? 😏 