### PR TITLE
Add bufferEntireResponse flag where needed

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -71,8 +71,7 @@ export default (base: ServiceBase) => {
     let searchConfig: SearchConfig = answerSpec.searchConfig;
     const reportConfigWithResponseBufferingSet: StandardReportConfig = {
       ...reportConfig,
-      bufferEntireResponse: reportConfig.bufferEntireResponse ?? true,
-      // bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
+      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
     };
     let body: StandardSearchReportRequest = {
       searchConfig,

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -65,7 +65,6 @@ export default (base: ServiceBase) => {
    * This method uses the deprecated AnswerSpec and AnswerFormatting for backwards compatibility with bulk of client code
    */
   async function getAnswerJson(answerSpec: AnswerSpec, reportConfig: StandardReportConfig, viewFilters?: FilterValueArray): Promise<Answer> {
-    debugger;
     const question = await base.findQuestion(answerSpec.searchName);
     const recordClass = await base.findRecordClass(question.outputRecordClassName);
     let url = base.getStandardSearchReportEndpoint(recordClass.urlSegment, question.urlSegment);

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -65,6 +65,7 @@ export default (base: ServiceBase) => {
    * This method uses the deprecated AnswerSpec and AnswerFormatting for backwards compatibility with bulk of client code
    */
   async function getAnswerJson(answerSpec: AnswerSpec, reportConfig: StandardReportConfig, viewFilters?: FilterValueArray): Promise<Answer> {
+    debugger;
     const question = await base.findQuestion(answerSpec.searchName);
     const recordClass = await base.findRecordClass(question.outputRecordClassName);
     let url = base.getStandardSearchReportEndpoint(recordClass.urlSegment, question.urlSegment);

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -68,8 +68,15 @@ export default (base: ServiceBase) => {
     const question = await base.findQuestion(answerSpec.searchName);
     const recordClass = await base.findRecordClass(question.outputRecordClassName);
     let url = base.getStandardSearchReportEndpoint(recordClass.urlSegment, question.urlSegment);
-    let searchConfig: SearchConfig = answerSpec.searchConfig
-    let body: StandardSearchReportRequest = { searchConfig, reportConfig };
+    let searchConfig: SearchConfig = answerSpec.searchConfig;
+    const reportConfigWithResponseBufferingSet: StandardReportConfig = {
+      ...reportConfig,
+      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
+    };
+    let body: StandardSearchReportRequest = {
+      searchConfig,
+      reportConfig: reportConfigWithResponseBufferingSet,
+    };
     return base._fetchJson<Answer>('post', url, stringify(body));
   }
 

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -65,13 +65,14 @@ export default (base: ServiceBase) => {
    * This method uses the deprecated AnswerSpec and AnswerFormatting for backwards compatibility with bulk of client code
    */
   async function getAnswerJson(answerSpec: AnswerSpec, reportConfig: StandardReportConfig, viewFilters?: FilterValueArray): Promise<Answer> {
+    debugger;
     const question = await base.findQuestion(answerSpec.searchName);
     const recordClass = await base.findRecordClass(question.outputRecordClassName);
     let url = base.getStandardSearchReportEndpoint(recordClass.urlSegment, question.urlSegment);
     let searchConfig: SearchConfig = answerSpec.searchConfig;
     const reportConfigWithResponseBufferingSet: StandardReportConfig = {
       ...reportConfig,
-      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
+      bufferEntireResponse: reportConfig.bufferEntireResponse ?? true,
     };
     let body: StandardSearchReportRequest = {
       searchConfig,
@@ -81,7 +82,6 @@ export default (base: ServiceBase) => {
   }
 
   async function downloadAnswer(answerRequest: AnswerRequest, target = '_blank') {
-
     let info = await getCustomSearchReportRequestInfo(answerRequest.answerSpec, answerRequest.formatting);
 
     // a submission must trigger a form download, meaning we must POST the form

--- a/Client/src/Service/Mixins/SearchReportsService.ts
+++ b/Client/src/Service/Mixins/SearchReportsService.ts
@@ -71,7 +71,8 @@ export default (base: ServiceBase) => {
     let searchConfig: SearchConfig = answerSpec.searchConfig;
     const reportConfigWithResponseBufferingSet: StandardReportConfig = {
       ...reportConfig,
-      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
+      bufferEntireResponse: reportConfig.bufferEntireResponse ?? true,
+      // bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
     };
     let body: StandardSearchReportRequest = {
       searchConfig,

--- a/Client/src/Service/Mixins/StepsService.ts
+++ b/Client/src/Service/Mixins/StepsService.ts
@@ -33,10 +33,14 @@ export default (base: ServiceBase) => {
   // get step's answer in wdk default json output format
   // TODO:  use a proper decoder to ensure correct decoding of the Answer
   function getStepStandardReport(stepId: number, reportConfig: StandardReportConfig, viewFilters: FilterValueArray | undefined, userId: string = 'current'): Promise<Answer> {
+    const reportConfigWithResponseBufferingSet: StandardReportConfig = {
+      ...reportConfig,
+      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
+    };
     return base.sendRequest(Decode.ok, {
       method: 'post',
       path: `/users/${userId}/steps/${stepId}/reports/standard`,
-      body: JSON.stringify({ reportConfig, viewFilters })
+      body: JSON.stringify({ reportConfig: reportConfigWithResponseBufferingSet, viewFilters })
     });
   }
 

--- a/Client/src/Service/Mixins/StepsService.ts
+++ b/Client/src/Service/Mixins/StepsService.ts
@@ -33,14 +33,10 @@ export default (base: ServiceBase) => {
   // get step's answer in wdk default json output format
   // TODO:  use a proper decoder to ensure correct decoding of the Answer
   function getStepStandardReport(stepId: number, reportConfig: StandardReportConfig, viewFilters: FilterValueArray | undefined, userId: string = 'current'): Promise<Answer> {
-    const reportConfigWithResponseBufferingSet: StandardReportConfig = {
-      ...reportConfig,
-      bufferEntireResponse: reportConfig.bufferEntireResponse ?? false,
-    };
     return base.sendRequest(Decode.ok, {
       method: 'post',
       path: `/users/${userId}/steps/${stepId}/reports/standard`,
-      body: JSON.stringify({ reportConfig: reportConfigWithResponseBufferingSet, viewFilters })
+      body: JSON.stringify({ reportConfig, viewFilters })
     });
   }
 

--- a/Client/src/Utils/WdkModel.ts
+++ b/Client/src/Utils/WdkModel.ts
@@ -359,6 +359,7 @@ export interface StandardReportConfig extends AttributesConfig {
   tables?: string[] | '__ALL_TABLES__';
   attachmentType?: string;
   includeEmptyTables?: boolean;
+  bufferEntireResponse?: boolean;
 }
 
 export interface AttributeSortingSpec {


### PR DESCRIPTION
**Before:**

<img width="769" alt="Screen Shot 2023-01-23 at 1 19 43 PM" src="https://user-images.githubusercontent.com/24446573/214130137-bccb33d2-4e14-45c7-a86f-d1c529a7bfe5.png">


**After**:

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/24446573/214129988-f9c053dc-e127-4666-a2d1-967a469c2622.png">

Companion PR: https://github.com/VEuPathDB/web-app-preferred-organisms/pull/9
