### PR TITLE
Warn against questions with too many organisms selected

### DIFF
--- a/Client/src/Views/Question/DefaultQuestionForm.scss
+++ b/Client/src/Views/Question/DefaultQuestionForm.scss
@@ -122,11 +122,10 @@
 
   /* Parameter-specific rules */
 
-  .wdk-CheckboxList, .wdk-TreeBoxParam {
+  .wdk-TreeBoxParam {
     width: 50%;
-  }
-
-  .wdk-CheckboxListLinks, .wdk-CheckboxTreeLinks > div {
-    text-align: left;
+    max-height: 60vh;
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -1,7 +1,7 @@
 import 'wdk-client/Views/Question/Params/TreeBoxParam.scss';
 
 import { intersection } from 'lodash';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import CheckboxTree, { CheckboxTreeProps, LinksPosition } from '@veupathdb/coreui/dist/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
@@ -144,7 +144,6 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
   const tree = props.parameter.vocabulary;
   const selectedNodes = props.selectedValues;
   const selectedLeaves = useSelectedLeaves(tree, selectedNodes);
-  const [ isBannerDismissed, setIsBannerDismissed ] = useState<boolean>(false)
   const shouldShowWarning = props.selectedValues.length > 5 ? true : false;
 
   const selectionCounts = useSelectionCounts(
@@ -161,10 +160,9 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
 
   return (
     <div>
-      {shouldShowWarning && !isBannerDismissed && 
         <Banner 
           banner={{
-            type: 'warning',
+            type: shouldShowWarning ? 'warning' : 'info',
             message: (
                 <span>
                   Selecting more than 5 organisms may result in poor performance and a cumbersome amount of data.
@@ -173,9 +171,7 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
                 </span>
             ),
           }}
-          onClose={() => setIsBannerDismissed(true)}
         />
-      }
       <div className="wdk-TreeBoxParam">
         <SelectionInfo parameter={props.parameter} {...selectionCounts} alwaysShowCount />
         <CheckboxTree 

--- a/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/Client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -1,7 +1,7 @@
 import 'wdk-client/Views/Question/Params/TreeBoxParam.scss';
 
 import { intersection } from 'lodash';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import CheckboxTree, { CheckboxTreeProps, LinksPosition } from '@veupathdb/coreui/dist/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import Icon from 'wdk-client/Components/Icon/IconAlt';
@@ -23,6 +23,7 @@ import {
 } from 'wdk-client/Actions/TreeBoxEnumParamActions';
 import { Action } from 'wdk-client/Actions';
 import { DispatchAction } from 'wdk-client/Core/CommonTypes';
+import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 
 // Types
 // -----
@@ -143,6 +144,8 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
   const tree = props.parameter.vocabulary;
   const selectedNodes = props.selectedValues;
   const selectedLeaves = useSelectedLeaves(tree, selectedNodes);
+  const [ isBannerDismissed, setIsBannerDismissed ] = useState<boolean>(false)
+  const shouldShowWarning = props.selectedValues.length > 5 ? true : false;
 
   const selectionCounts = useSelectionCounts(
     props.parameter.countOnlyLeaves,
@@ -157,11 +160,28 @@ export function TreeBoxEnumParamComponent(props: TreeBoxProps) {
     : props.wrapCheckboxTreeProps(checkboxTreeProps);
 
   return (
-    <div className="wdk-TreeBoxParam">
-      <SelectionInfo parameter={props.parameter} {...selectionCounts} alwaysShowCount />
-      <CheckboxTree 
-        {...wrappedCheckboxTreeProps} 
-      />
+    <div>
+      {shouldShowWarning && !isBannerDismissed && 
+        <Banner 
+          banner={{
+            type: 'warning',
+            message: (
+                <span>
+                  Selecting more than 5 organisms may result in poor performance and a cumbersome amount of data.
+                  <br/>
+                  Consider setting "My Organism Preferences" to filter by organisms of interest.
+                </span>
+            ),
+          }}
+          onClose={() => setIsBannerDismissed(true)}
+        />
+      }
+      <div className="wdk-TreeBoxParam">
+        <SelectionInfo parameter={props.parameter} {...selectionCounts} alwaysShowCount />
+        <CheckboxTree 
+          {...wrappedCheckboxTreeProps} 
+        />
+      </div>
     </div>
   );
 }

--- a/Client/src/Views/Question/Params/TreeBoxParam.scss
+++ b/Client/src/Views/Question/Params/TreeBoxParam.scss
@@ -1,9 +1,3 @@
-.wdk-TreeBoxParam {
-  .wdk-CheckboxTree {
-    margin-left: -1rem;
-  }
-}
-
 div.wdk-TreeBoxParam div.treeCount {
   font-style: italic; 
   font-size: 1.3em;


### PR DESCRIPTION
Responds to [Redmine #47135](https://redmine.apidb.org/issues/47135) (`"Create warning message after a certain number of genomes chosen"`)

Looking into this issue pointed out that `CheckboxTree` isn't constrained vertically in our searches. It is very obvious when searching `Genes > Taxonomy > Organism` in VEuPathDB (shown in screencast 1). I went ahead and added a constraint to the overall height, plus fixed the search box and links (example from PlasmoDB shown in screencast 2).

Last, I've thrown a `Banner` component into the page if more than 5 organisms are selected just as a starting point (shown in screencast 3).

**Screencast 1**
![huge_tree](https://user-images.githubusercontent.com/69446567/213573842-e4c36f51-4c49-4cc1-89fc-00536edf06f4.gif)

**Screencast 2**
![huge_tree_resolved](https://user-images.githubusercontent.com/69446567/213573939-7fb0ea84-7bef-442f-872e-3c28c7f72b3b.gif)

**Screencast 3**
![banner_demo](https://user-images.githubusercontent.com/69446567/213574123-67765337-bdb6-4b2c-aaed-404114bb0c50.gif)



