### PR TITLE
Amend SelectionInfo message for when maxSelectedCount is 1

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Views/Question/Params/SelectionInfo.tsx
+++ b/Client/src/Views/Question/Params/SelectionInfo.tsx
@@ -18,14 +18,14 @@ export default function SelectionInfo(props: Props) {
   const isSingleSelect = maxSelectedCount === 1;
 
   const message = hasMin && hasMax
-    ? `between ${minSelectedCount} and ${maxSelectedCount} values required`
+    ? `${isSingleSelect ? '' : 'between ' + minSelectedCount + ' and '}${maxSelectedCount} ${valueDescription(maxSelectedCount)} required`
     : (hasMin && selectedCount > 0) ? `at least ${minSelectedCount} ${valueDescription(minSelectedCount)} required`
     : hasMax ? `at most ${maxSelectedCount} ${valueDescription(maxSelectedCount)} required`
     : null;
 
   const isCountInBounds = countInBounds(selectedCount, Math.max(minSelectedCount,1), maxSelectedCount);
 
-  // This is usd in TreeBoxParam (eg organism): red if 0 selected
+  // This is used in TreeBoxParam (eg organism): red if 0 selected
   const countColor = isCountInBounds
     ? 'black'
     : 'red';

--- a/Client/src/Views/Question/Params/SelectionInfo.tsx
+++ b/Client/src/Views/Question/Params/SelectionInfo.tsx
@@ -15,6 +15,7 @@ export default function SelectionInfo(props: Props) {
   const { minSelectedCount, maxSelectedCount } = props.parameter;
   const hasMin = minSelectedCount > 0;
   const hasMax = maxSelectedCount > 0;
+  const isSingleSelect = maxSelectedCount === 1;
 
   const message = hasMin && hasMax
     ? `between ${minSelectedCount} and ${maxSelectedCount} values required`
@@ -33,7 +34,7 @@ export default function SelectionInfo(props: Props) {
 
   return (
     <div className="treeCount">
-      <span className={countColor}>{props.selectedCount} selected</span>, out of {props.allCount}
+      <span className={countColor}>{props.selectedCount} selected</span>{!isSingleSelect && <>, out of {props.allCount}</>}
       {
         !isCountInBounds && message &&
         <>


### PR DESCRIPTION
Accompanies https://github.com/VEuPathDB/web-app-preferred-organisms/pull/12 in order to better reflect components that are limited to one selection.

Before:
![image](https://user-images.githubusercontent.com/69446567/214706265-17c3c139-a7aa-4a04-b649-ca20bb1ec4f9.png)

After:
- _**see below for updated screenshot**_