### PR TITLE
Amend reset btn verbiage in question forms

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Controllers/QuestionController.tsx
+++ b/Client/src/Controllers/QuestionController.tsx
@@ -255,7 +255,7 @@ function useResetFormConfig(
             resetFormContent: (
               <React.Fragment>
                 <IconAlt fa="refresh" />
-                Reset values
+                Reset values to default
               </React.Fragment>
             )
           }


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/47596 which asks to change the reset button's verbiage in the question forms.

Before:
![image](https://user-images.githubusercontent.com/69446567/216420737-e3d0b751-f0d2-4f7c-ab0f-7952c4a7d1f0.png)

After:
![image](https://user-images.githubusercontent.com/69446567/216420876-e54f13e9-8366-4ea3-bd34-0aaef3066158.png)