### PR TITLE
Add fullscreen routes

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/Layout/Page.tsx
+++ b/Client/src/Components/Layout/Page.tsx
@@ -16,9 +16,11 @@ export type Props = RouteComponentProps<any> & {
   classNameModifier?: string;
   children: React.ReactChild;
   requireLogin: boolean;
+  isFullScreen?: boolean;
 };
 
 const cx = makeClassNameHelper('wdk-RootContainer');
+const pageContentCx = makeClassNameHelper('wdk-PageContent');
 
 function Page(props: Props) {
   const dispatch = useDispatch();
@@ -51,9 +53,9 @@ function Page(props: Props) {
 
   return (
     <div className={cx('', props.classNameModifier)}>
-      <ErrorBoundary><Header/></ErrorBoundary>
-      <div className="wdk-PageContent">{props.children}</div>
-      <ErrorBoundary><Footer/></ErrorBoundary>
+      {!props.isFullScreen && <ErrorBoundary><Header/></ErrorBoundary>}
+      <ErrorBoundary><div className={pageContentCx('', props.isFullScreen && 'fullscreen')}>{props.children}</div></ErrorBoundary>
+      {!props.isFullScreen && <ErrorBoundary><Footer/></ErrorBoundary>}
     </div>
   );
 }

--- a/Client/src/Core/Root.tsx
+++ b/Client/src/Core/Root.tsx
@@ -121,8 +121,8 @@ export default class Root extends React.Component<Props, State> {
     const activeRoute = routes.find(({ path, exact = true }) =>
       matchPath(location.pathname, { path, exact })
     );
-    const rootClassNameModifier =
-      activeRoute && activeRoute.rootClassNameModifier;
+    const rootClassNameModifier = activeRoute?.rootClassNameModifier;
+    const isFullscreen = activeRoute?.isFullscreen;
     return (
       <Provider store={this.props.store}>
         <ErrorBoundary>
@@ -136,6 +136,7 @@ export default class Root extends React.Component<Props, State> {
                 <Page
                   classNameModifier={rootClassNameModifier}
                   requireLogin={this.props.requireLogin}
+                  isFullScreen={isFullscreen}
                 >
                   {staticContent ? (
                     safeHtml(staticContent, null, 'div')

--- a/Client/src/Core/RouteEntry.tsx
+++ b/Client/src/Core/RouteEntry.tsx
@@ -8,6 +8,7 @@ export interface RouteEntry {
   readonly component: RouteProps['component'];
   readonly requiresLogin?: boolean;
   readonly rootClassNameModifier?: string;
+  readonly isFullscreen?: boolean;
 }
 
 export function parseQueryString(props: RouteComponentProps<any>): Record<string, string> {

--- a/Client/src/Core/Style/wdk-Common.scss
+++ b/Client/src/Core/Style/wdk-Common.scss
@@ -209,6 +209,9 @@ img[data-assets-src][src] {
 .wdk-PageContent {
   position: relative;
   padding: 0 2em;
+  &__fullscreen {
+    padding: 0;
+  }
 }
 
 .wdk-Link {


### PR DESCRIPTION
This PR allows a route to declare that it is fullscreen. This will cause the header and footer to not be rendered. It will also remove any padding from the `PageContent` container.