### PR TITLE
Add traceid header to requests

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Service/Mixins/LoginService.ts
+++ b/Client/src/Service/Mixins/LoginService.ts
@@ -1,5 +1,6 @@
 import { ServiceBase } from 'wdk-client/Service/ServiceBase';
 import * as Decode from 'wdk-client/Utils/Json';
+import { makeTraceid } from '../ServiceUtils';
 
 /** This is for POST requests */
 export type TryLoginResponse = {
@@ -35,7 +36,12 @@ export default (base: ServiceBase) => {
   async function logout() {
     return fetch(
       `${base.serviceUrl}/logout`,
-      { credentials: 'include' }
+      {
+        credentials: 'include',
+        headers: {
+          traceid: makeTraceid(),
+        }
+      }
     );
   }
 

--- a/Client/src/Service/Mixins/StepAnalysisService.ts
+++ b/Client/src/Service/Mixins/StepAnalysisService.ts
@@ -4,6 +4,7 @@ import { stepAnalysisDecoder, stepAnalysisConfigDecoder, stepAnalysisTypeDecoder
 import { parametersDecoder } from 'wdk-client/Service/Mixins/SearchesService';
 import { Parameter, ParameterValues } from 'wdk-client/Utils/WdkModel';
 import { extractParamValues } from 'wdk-client/Utils/WdkUser';
+import { makeTraceid } from '../ServiceUtils';
 
 export type StepAnalysisWithParameters = StepAnalysisType & {
   parameters: Parameter[];
@@ -108,7 +109,10 @@ export default (base: ServiceBase) => {
   }
 
   function updateStepAnalysisForm(stepId: number, analysisId: number, formParams: FormParams) {
-    const headers = new Headers({ 'Content-Type': 'application/json'});
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      traceid: makeTraceid(),
+    });
     if (base._version) headers.append(CLIENT_WDK_VERSION_HEADER, String(base._version))
     return fetch(`${base.serviceUrl}/users/current/steps/${stepId}/analyses/${analysisId}`, {
       headers,

--- a/Client/src/Service/Mixins/TemporaryFilesService.ts
+++ b/Client/src/Service/Mixins/TemporaryFilesService.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { ServiceBase } from 'wdk-client/Service/ServiceBase';
 import { ServiceError } from 'wdk-client/Service/ServiceError';
-import { appendUrlAndRethrow } from '../ServiceUtils';
+import { appendUrlAndRethrow, makeTraceid } from '../ServiceUtils';
 
 export default (base: ServiceBase) => {
 
@@ -12,7 +12,10 @@ export default (base: ServiceBase) => {
     return fetch(base.serviceUrl + path, {
       method: 'POST',
       credentials: 'include',
-      body: formData
+      body: formData,
+      headers: {
+        traceid: makeTraceid(),
+      }
     }).then(response => {
       if (response.ok) {
         const id = response.headers.get('ID');

--- a/Client/src/Service/ServiceBase.ts
+++ b/Client/src/Service/ServiceBase.ts
@@ -10,7 +10,7 @@ import * as Decode from 'wdk-client/Utils/Json';
 import { alert } from 'wdk-client/Utils/Platform';
 import { pendingPromise } from 'wdk-client/Utils/PromiseUtils';
 import { Question } from 'wdk-client/Utils/WdkModel';
-import { appendUrlAndRethrow } from './ServiceUtils';
+import { appendUrlAndRethrow, makeTraceid } from './ServiceUtils';
 
 
 
@@ -214,7 +214,10 @@ export const ServiceBase = (serviceUrl: string) => {
   }
 
   function _fetchJson<T>(method: string, url: string, body?: string, isBaseUrl?: boolean) {
-    const headers = new Headers({ 'Content-Type': 'application/json'});
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      traceid: makeTraceid(),
+    });
     if (_version) headers.append(CLIENT_WDK_VERSION_HEADER, String(_version));
     return fetchWithRetry(
       1,

--- a/Client/src/Service/ServiceUtils.ts
+++ b/Client/src/Service/ServiceUtils.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid';
+
 export const appendUrlAndRethrow = (url: string) => (error: unknown) => {
   if (error instanceof Error) {
     const { message } = error;
@@ -6,4 +8,8 @@ export const appendUrlAndRethrow = (url: string) => (error: unknown) => {
       : `${message} (Attempting to request ${url}.)`;
   }
   throw error;
+}
+
+export function makeTraceid() {
+  return uuid().replaceAll('-', '');
 }


### PR DESCRIPTION
This PR adds a `traceid` header to requests made to the WDK service.