### PR TITLE
Resolve still-present column overflow issues

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/src/Components/Mesa/Ui/DataTable.jsx
+++ b/Client/src/Components/Mesa/Ui/DataTable.jsx
@@ -46,7 +46,8 @@ class DataTable extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
-      this.props.columns.map(c => c.name).toString() !== prevProps.columns.map(c => c.name).toString()
+      this.props.columns.map(c => c.name).toString() !== prevProps.columns.map(c => c.name).toString() ||
+      !isEqual(this.props.uiState, prevProps.uiState)
     ) {
       this.setDynamicWidths();
       this.attachLoadEventHandlers();

--- a/Client/src/Components/Mesa/style/Vars.scss
+++ b/Client/src/Components/Mesa/style/Vars.scss
@@ -1,4 +1,4 @@
-$borderColor: rgba(0, 0, 0, 0.08);
+$borderColor: rgba(0, 0, 0, 0.2);
 $accentColor: #069;
 $borderRadius: 5px;
 $fontSize: 13px;

--- a/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
+++ b/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
@@ -3,13 +3,21 @@ import { isEqual, truncate } from 'lodash';
 import { RecordInstance, AttributeField } from 'wdk-client/Utils/WdkModel';
 import { safeHtml, wrappable } from 'wdk-client/Utils/ComponentUtils';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
+import { useIsRefOverflowingHorizontally } from 'wdk-client/Hooks/Overflow';
 
 interface AttributeCellProps {
   attribute: AttributeField;
   recordInstance: RecordInstance;
 }
 
-function AttributeCell({
+function AttributeCell(props: AttributeCellProps) {
+  const { attribute, recordInstance } = props;
+  const attributeValue = recordInstance.attributes[attribute.name];
+  const key = typeof attributeValue === 'string' ? attributeValue : attributeValue?.displayText || attributeValue?.url || '';
+  return <AttributeCellInner {...props} key={key} />;
+}
+
+function AttributeCellInner({
   attribute,
   recordInstance,
 }: AttributeCellProps) {
@@ -20,12 +28,14 @@ function AttributeCell({
   };
   const ref = useRef<HTMLDivElement>(null);
   const [ styleSpec, setStyleSpec ] = useState<React.CSSProperties>(defaultStyleSpec);
+  const isOverflowing = useIsRefOverflowingHorizontally(ref);
   
   useLayoutEffect(() => {
     if (!ref.current) return;
     if (
       ref.current.innerText.length > attribute.truncateTo &&
-      isEqual(styleSpec, defaultStyleSpec) 
+      isEqual(styleSpec, defaultStyleSpec) &&
+      isOverflowing
       ) {
         setStyleSpec({
           ...defaultStyleSpec,

--- a/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
+++ b/Client/src/Views/ResultTableSummaryView/AttributeCell.tsx
@@ -3,7 +3,6 @@ import { isEqual, truncate } from 'lodash';
 import { RecordInstance, AttributeField } from 'wdk-client/Utils/WdkModel';
 import { safeHtml, wrappable } from 'wdk-client/Utils/ComponentUtils';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
-import { useIsRefOverflowingHorizontally } from 'wdk-client/Hooks/Overflow';
 
 interface AttributeCellProps {
   attribute: AttributeField;
@@ -21,14 +20,12 @@ function AttributeCell({
   };
   const ref = useRef<HTMLDivElement>(null);
   const [ styleSpec, setStyleSpec ] = useState<React.CSSProperties>(defaultStyleSpec);
-  const isOverflowing = useIsRefOverflowingHorizontally(ref);
   
   useLayoutEffect(() => {
     if (!ref.current) return;
     if (
       ref.current.innerText.length > attribute.truncateTo &&
-      isEqual(styleSpec, defaultStyleSpec) &&
-      isOverflowing
+      isEqual(styleSpec, defaultStyleSpec) 
       ) {
         setStyleSpec({
           ...defaultStyleSpec,

--- a/Client/src/Views/ResultTableSummaryView/ResultTableSummaryView.scss
+++ b/Client/src/Views/ResultTableSummaryView/ResultTableSummaryView.scss
@@ -100,6 +100,7 @@
 
     th, td {
       padding: 4px;
+      padding-right: 6px;
       vertical-align: middle;
     }
 


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/WDKClient/issues/285

It seems the `useIsRefOverflowingHorizontally` gets out of sync and thus its use as a condition in the truncation logic is problematic. Removing it seems to behave as desired, leaving only this check to determine truncation:
```js
if (
  ref.current.innerText.length > attribute.truncateTo &&
  isEqual(styleSpec, defaultStyleSpec) 
)
```