### PR TITLE
Ensure `exports` is not defined when loading datatables script

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/wdk-client",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/Client/vendored/datatables.js
+++ b/Client/vendored/datatables.js
@@ -1,3 +1,7 @@
+!function() {
+    // Some dependencies define a global `exports` variable. which
+    // makes these scripts break when being loaded via the webpack script-loader.
+    var exports = void 0;
 /*
  * This combined file was created by the DataTables downloader builder:
  *   https://datatables.net/download
@@ -30816,3 +30820,5 @@ return Scroller;
 }));
 
 
+
+}();

--- a/Client/vendored/datatables.min.js
+++ b/Client/vendored/datatables.min.js
@@ -1,3 +1,7 @@
+!function() {
+    // Some dependencies define a global `exports` variable. which
+    // makes these scripts break when being loaded via the webpack script-loader.
+    var exports = void 0;
 /*
  * This combined file was created by the DataTables downloader builder:
  *   https://datatables.net/download
@@ -339,3 +343,4 @@ k.register("scroller().rowToPixels()",function(a,b,c){var d=this.context;if(d.le
 function(c,d){if(c.oScroller){var e=b.rows({order:"applied",search:"applied"}).indexes().indexOf(d);c.oScroller.fnScrollToRow(e,a)}});return this});k.register("scroller.measure()",function(a){this.iterator("table",function(b){b.oScroller&&b.oScroller.fnMeasure(a)});return this});k.register("scroller.page()",function(){var a=this.context;if(a.length&&a[0].oScroller)return a[0].oScroller.fnPageInfo()});return h});
 
 
+}();


### PR DESCRIPTION
This fixes an issue where a third party dependency creates a global `exports` object, breaking the feature detection used by these scripts, to determine if they are being run in a CommonJS environment.